### PR TITLE
docs: dispute-pack hardening design record and execution plan

### DIFF
--- a/docs/DISPUTE_HARDENING.md
+++ b/docs/DISPUTE_HARDENING.md
@@ -1,0 +1,142 @@
+# Dispute-Pack Hardening — Design Record
+
+**Status:** Accepted (design) · **Scope:** Where dispute packs and full transaction descriptions live, and how we make them tamper-evident against a colluding-banks adversary.
+
+**Core goal of the system:** prove *which AI agent performed which action, on whose side, and when*, in a payments context — such that the record survives a hostile database administrator.
+
+This document has two blocks:
+- **Block 1 — For the Team** — the engineering decision record: threat model, resolved decisions, defense-in-depth map, residual risks, and the implementation delta order.
+- **Block 2 — For the Pitch** — the investor-facing narrative of why this is defensible.
+
+---
+
+# Block 1 — For the Team (Engineering Decision Record)
+
+## 1. The problem we started from
+
+Today the chain anchors **only a hash** of each dispute pack; the packs themselves — the full transaction description — live in **Bank-A's and Bank-B's SQLite**. The stated fear: *"a DB admin at either bank can edit the stored data, and proving anything afterwards is hard."*
+
+First correction, because it reframes everything:
+
+> A naive **row edit is already detectable.** SQL stores the signed `raw_payload`, whose content is committed by hash (`args_hash`, `output_hash`, `intent_hash`). The chain is *on-chain Merkle root → sha256(signature) → Ed25519 signature → content hash*. Edit the payload and the signature no longer verifies; edit the signature and the Merkle proof no longer reconciles to the anchored root. Signatures already stop an outsider **without the key**.
+
+The residual holes are elsewhere, and they are what this design closes:
+
+| Hole | Why signatures don't cover it |
+|------|-------------------------------|
+| **Self-fabrication** | Keys are generated in-proxy at boot (`generateKeyPair`) and fully held by the bank. The key-holder can mint or re-sign records. |
+| **Deletion / suppression** | The on-chain root doesn't enumerate what *should* exist. A dropped row / un-anchored transaction leaves no trace. |
+| **Content unavailability** | Plaintext args/output are *"hashed, NOT stored"*. A pack proves a commitment existed, not *what* it said. |
+| **Identity repudiation** | `register-peer-key` is mutable; a party can later claim *"that wasn't my key."* |
+| **Anchoring asymmetry** | Only Bank-B anchors, in arbitrary batches, on demand — Bank-A's history depends on B's honesty, with an unbounded pre-anchor window. |
+
+## 2. Threat model (the load-bearing choice)
+
+**Adversary: both banks colluding against an external party (client / regulator).** We tolerate collusion of the two settlement parties and still keep the record provable.
+
+Consequence, stated plainly: **in a pure two-party system this is impossible without a third independent key.** The blockchain anchor alone only defeats *post-hoc* rewriting and fixes *ordering/time*; two parties colluding *at creation time* can build an internally consistent fake history and anchor that. So the design **requires a witness outside both banks.**
+
+## 3. Resolved decisions
+
+| # | Decision | Choice | Threat it closes |
+|---|----------|--------|------------------|
+| 1 | Threat model | Both banks collude vs. external party | sets the bar |
+| 2 | Third witness | **TrustAgentAI Cloud** as co-signer | bank collusion ≠ sufficient |
+| 3 | Trust in witness | Semi-trusted **but verifiable** | don't just relocate the problem |
+| 4 | Log structure | **Per-party hash-chain + checkpoints** | deletion / reorder / suppression |
+| 5 | Content store | **Content-addressed WORM**, cross-held (TrustAgentAI + client + banks) | *what* survives collusion |
+| 6 | Key custody | **Persisted software keys** (encrypted at rest), KEK isolated from DBA | admin ≠ signer, durable identity |
+| 7 | Anchor topology | **TrustAgentAI-centric checkpoint** (MVP) | tamper-evidence of order/time |
+| 8 | Co-sign path | **Sync inline** + degraded-mode fallback | suppression-at-origin |
+| 9 | Degraded mode | **On-chain heartbeat + reconciliation window + value cap** | the availability escape-hatch |
+| 10 | Key registry | **TrustAgentAI key-transparency**, rotations endorsed by prior key | *whose* key / repudiation |
+| 11 | Content access | **Envelope-encryption**, per-tx DEK + regulator **escrow** | confidentiality at dispute time |
+
+**"When" is derived, not a separate mechanism:** the authoritative timestamp is TrustAgentAI's co-signature (it sits on the critical path), bounded above by the anchor block time and the on-chain heartbeat. No separate RFC-3161 TSA required.
+
+## 4. Defense-in-depth map — layer → threat
+
+Each layer closes exactly one class; none is asked to do another's job.
+
+- **Ed25519 signature** → *tampering* (row edits).
+- **Per-party hash-chain (`seq` + `prev_hash`) + anchored checkpoints** → *deletion, reorder, suppression* (a gap between two anchored checkpoints is provable).
+- **Independent inline co-signer (TrustAgentAI) + key-transparency registry** → *fabrication* (a hidden or forged transaction cannot produce a valid witness signature).
+- **Checkpoints + on-chain heartbeat** → *"when"* (monotonic public time; ordering cannot be rewound).
+- **WORM content store + envelope-encryption with escrow** → *"what"* (the pre-image is available and confidential).
+- **Bounds on the escape hatches** (degraded cap, escrow quorum, checkpoint cadence) → keep the known SPOFs small rather than pretending they don't exist.
+
+## 5. Residual risks — knowingly accepted
+
+These are **explicit trade-offs**, not oversights. A reviewer/regulator should see them stated.
+
+1. **Software keys, not HSM.** An admin with host/process access can exfiltrate a key and append fabrications. This is bounded — not eliminated — by checkpoint cadence + cross-holding, and it rests on **KEK isolation** (the decryption key must live in a separate secret store, under a role that does not overlap DBA — otherwise "encrypted at rest" is theatre). *Upgrade path: KMS/HSM non-extractable keys; threshold/MPC for the high-value TrustAgentAI key.*
+2. **TrustAgentAI-centric anchoring (not mutual).** TrustAgentAI is a **liveness dependency** on the critical path — a hard availability SPOF. Ordering guarantees hold only while the heartbeat runs. *Upgrade path: mutual anchoring — each party anchors its own chain HEAD.*
+3. **Semi-trusted witness.** "Both banks collude" is closed. **"TrustAgentAI + one bank collude" is NOT closed** — that coalition can fabricate. This is the central trust compromise of the MVP and must be disclosed.
+4. **Escrow key is a trust concentration.** Whoever holds escrow can decrypt everything. **Escrow must not sit with TrustAgentAI** (else "witness + escrow = silent omniscience over all payments"). Holder = the regulator, or a threshold quorum (regulator + 1 party).
+
+## 6. Implementation delta order (grounded in current code)
+
+Ordered by dependency; #1 unblocks the rest.
+
+1. **Durable keys.** Replace boot-time `generateKeyPair(PROXY_KID)` with load-or-create from an encrypted keystore; KEK from a separate secret store.
+   → [Bank-A/proxy/src/server.ts:34](../Bank-A/proxy/src/server.ts#L34), [Bank-B/proxy/src/server.ts:84](../Bank-B/proxy/src/server.ts#L84), [trust-agent/src/crypto.ts](../trust-agent/src/crypto.ts)
+2. **Hash-chain.** Add `seq` + `prev_hash` to the `envelopes` table; enforce append-only linkage on write.
+   → [Bank-A/proxy/src/db.ts](../Bank-A/proxy/src/db.ts), [Bank-B/proxy/src/db.ts](../Bank-B/proxy/src/db.ts)
+3. **TrustAgentAI co-sign service (new).** Inline endpoint between Phase 2 and Phase 3; co-signs, appends to its own hash-chain, gates finality. Wire into the handshake in `ProxyAGateway`.
+4. **Checkpoint anchoring + heartbeat.** Anchor the per-party chain HEAD checkpoint (not an arbitrary signature batch); add a periodic signed on-chain heartbeat publisher.
+   → [Bank-B/merkle-anchor/app/accounting_agent.py](../Bank-B/merkle-anchor/app/accounting_agent.py), [Bank-B/merkle-anchor/infra/notary.py](../Bank-B/merkle-anchor/infra/notary.py), [Bank-B/merkle-anchor/domain/merkle.py](../Bank-B/merkle-anchor/domain/merkle.py)
+5. **WORM content store + envelope-encryption.** Persist plaintext args/output as encrypted, content-addressed blobs (per-tx DEK); cross-push to TrustAgentAI + client. Bind the content hash into the chain. Today these are *"hashed, NOT stored"*.
+   → [trust-agent/src/envelopes.ts:23](../trust-agent/src/envelopes.ts#L23)
+6. **Key-transparency registry.** Replace mutable `register-peer-key` with an append-only, anchored registry: validity windows, revocation as an append event, rotations endorsed by the prior key.
+   → [Bank-A/proxy/src/key-exchange.ts](../Bank-A/proxy/src/key-exchange.ts)
+7. **Degraded-mode discipline.** Detect heartbeat gaps, enforce a reconciliation window (co-sign within N or auto-flag invalid) and a value/rate cap on degraded transactions.
+
+## 7. Verification (what an auditor runs)
+
+A third party proves the full chain end-to-end without trusting any single party:
+
+1. **Content:** fetch the WORM blob by content hash → `sha256` matches the value committed in the envelope.
+2. **Envelope:** each envelope's Ed25519 signature verifies under the key that the **key-transparency registry** shows valid at that envelope's timestamp.
+3. **Continuity:** `prev_hash` links form an unbroken chain; `seq` has no gaps between two anchored checkpoints.
+4. **Anchor:** the checkpoint HEAD is present on Base Sepolia; the heartbeat sequence has no unexplained gap around the transaction time.
+5. **Witness:** the transaction carries TrustAgentAI's inline co-signature (or a valid, capped, reconciled degraded record).
+
+Any tamper, deletion, fabrication, or suppression breaks at least one of these five checks.
+
+---
+
+# Block 2 — For the Pitch
+
+## The one-liner
+
+**We make it impossible for a bank to secretly rewrite what an AI agent did with your money — even if two banks conspire to do it together.**
+
+## The problem
+
+AI agents are starting to move money on our behalf. When something goes wrong, one question decides everything: *which agent did what, on whose side, and when?* Today that record lives inside each bank's own database. Whoever administers that database can quietly change it — and once the record is changed, there is no independent way to prove what it originally said. "Trust us, our logs are correct" is not an answer a regulator, a court, or a defrauded customer can accept.
+
+## The insight
+
+Cryptographic signatures already stop an *outsider* from tampering. The hard part is the *insider* — and the truly hard part is **two insiders who agree to lie together.** You cannot solve that with two parties alone; someone with no stake in the lie has to be in the loop at the moment the transaction happens.
+
+So we split authority:
+
+- **The bank** proves it *settled* the payment.
+- **TrustAgentAI** — independent of both banks — proves *which agent requested it, and when*, by co-signing the transaction **inline, before it can complete.**
+
+Neither side can forge the other's half. A transaction that skips our witness simply isn't a valid transaction — there's nothing to point to. That single move turns "trust each bank's database" into "no bank, and no pair of banks, can fabricate, alter, or hide a record without it being provable."
+
+## What makes it credible (not just a claim)
+
+- **Public, permanent timeline.** Every batch of records is anchored to a public blockchain (Base Sepolia). The order of history is fixed and cannot be rewound.
+- **Deletion becomes visible.** Records are chained and numbered; a missing entry leaves a provable gap — you can't quietly drop a transaction.
+- **The evidence itself survives.** The full transaction description is stored tamper-evidently and held by more than one party, encrypted, so it's still there — and still confidential — when a dispute arises.
+- **We hold ourselves accountable too.** Our own witness log is append-only and anchored, so even we can't rewrite it after the fact. A regulator gets a sealed key to open the specific records in dispute — and nothing more.
+
+## The honest edge (why this reads as real, not hand-wavy)
+
+We are explicit about the trust boundary: today the strong guarantee is *"no bank, or pair of banks, can cheat."* Removing us as a trusted party entirely — the fully decentralized version — is on the roadmap (hardware key custody, mutual anchoring, threshold escrow). We ship the layer that closes the threat customers actually face now, and we've mapped exactly how each remaining assumption gets retired.
+
+## Why now
+
+Agent-driven payments are arriving before the accountability layer for them exists. The winner in this space isn't the fastest agent — it's the one whose actions are **provable**. That provability is the product.

--- a/docs/execution_plan.md
+++ b/docs/execution_plan.md
@@ -1,0 +1,115 @@
+# Execution Plan — Dispute-Pack Hardening
+
+**Audience:** an AI coding agent (any model) picking up execution cold.
+**Companion doc:** [DISPUTE_HARDENING.md](DISPUTE_HARDENING.md) holds the *why* (threat model, decision rationale, residual risks). This file holds the *what to build, in what order, and how to know it's done*.
+
+> Read [DISPUTE_HARDENING.md](DISPUTE_HARDENING.md) first. Do not re-litigate the decisions below — they are settled. If you believe one is wrong, raise it explicitly before changing course.
+
+---
+
+## 1. Mission
+
+Harden where dispute packs (full transaction descriptions) are stored so the record proves *which AI agent did which action, on whose side, and when* — and survives a **collusion of both banks** against an external party (client/regulator).
+
+Independent witness = **TrustAgentAI Cloud**, a co-signer outside both banks, semi-trusted **but verifiable** (its own log is append-only + anchored, so even it cannot silently rewrite history).
+
+## 2. Settled decisions (reference)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Threat model | Both banks collude vs. external party |
+| 2 | Third witness | TrustAgentAI Cloud as inline co-signer |
+| 3 | Trust in witness | Semi-trusted but verifiable |
+| 4 | Log structure | Per-party hash-chain (`seq` + `prev_hash`) + anchored checkpoints |
+| 5 | Content store | Content-addressed WORM, cross-held (TrustAgentAI + client + banks) |
+| 6 | Key custody | Persisted software keys, encrypted at rest, KEK isolated from DBA |
+| 7 | Anchor topology | TrustAgentAI-centric checkpoint (MVP) |
+| 8 | Co-sign path | Sync inline + degraded-mode fallback |
+| 9 | Degraded mode | On-chain heartbeat + reconciliation window + value cap |
+| 10 | Key registry | TrustAgentAI key-transparency, rotations endorsed by prior key |
+| 11 | Content access | Envelope-encryption, per-tx DEK + regulator escrow (escrow NOT held by TrustAgentAI) |
+
+## 3. Repository orientation
+
+Monorepo, three runtime languages:
+
+- **`trust-agent/`** — TypeScript core library (`@trustagentai/a2a-core`). Holds crypto ([src/crypto.ts](../trust-agent/src/crypto.ts)) and envelope builders ([src/envelopes.ts](../trust-agent/src/envelopes.ts)). The proxies depend on it via `file:../../trust-agent`.
+- **`Bank-A/proxy/`, `Bank-B/proxy/`** — TypeScript/Express proxies. ESM (`"type":"module"`), `better-sqlite3` (WAL). Entry: `src/server.ts`. Persistence: `src/db.ts`. Build: `npm run build` (tsc) → `dist/`. Start: `npm start`.
+- **`Bank-B/merkle-anchor/`** — Python/Flask notary. Builds Merkle tree ([domain/merkle.py](../Bank-B/merkle-anchor/domain/merkle.py)), anchors to Base Sepolia ([infra/notary.py](../Bank-B/merkle-anchor/infra/notary.py)), reads the shared SQLite via Docker volume.
+- **`frontend/`** — React + nginx. Dispute console: `src/components/DisputeConsole.tsx`.
+- **`docker-compose.yml`** — wires bank-a-agent, bank-a-proxy, bank-b-agent, bank-b-proxy, bank-b-anchor, frontend.
+
+**Current key API** ([trust-agent/src/crypto.ts](../trust-agent/src/crypto.ts)):
+```ts
+export interface KeyPair { privateKey: Uint8Array; publicKey: Uint8Array; kid: string; }
+export async function generateKeyPair(kid: string): Promise<KeyPair>
+```
+Keys are generated fresh at boot in `server.ts` and never persisted — this is the target of Delta #1.
+
+### ⚠ Test infrastructure gap
+The proxies have **no test runner** (`package.json` scripts are only `build`/`start`). Delta #1 must **stand up a test harness first**. Recommended: **Vitest** (native ESM + TS, works with the existing tsconfig). Add `"test"` and `"test:coverage"` scripts. This is a prerequisite, not optional — the working agreement below mandates TDD.
+
+## 4. Working agreement (non-negotiable)
+
+- **TDD.** RED → GREEN → REFACTOR. Write the failing test first, then the minimal implementation. Confirm the test failed before implementing.
+- **Coverage ≥ 80%** on new/changed modules.
+- **No secrets in source.** Keys, KEKs, RPC keys, escrow keys → environment / secret store only. The `.env` is gitignored; never commit real key material.
+- **Immutability & small files** (≤ ~400 lines/file, ≤ ~50 lines/function). New objects over mutation.
+- **Conventional commits** (`feat:`, `test:`, `refactor:`, `docs:`, `chore:`). Attribution is disabled globally.
+- **Branch, never `main`.** One branch per delta, e.g. `feat/delta-1-durable-keys`. Open a PR; do not self-merge to main.
+- **Preserve wire compatibility.** Envelope JSON shape, `signed_digest` rule (`SHA-256(JCS(envelope − signatures))`), and existing SSE event names must not break unless a delta explicitly changes them.
+
+## 5. Delta backlog (execute in order — each unblocks the next)
+
+### Delta #1 — Durable, custodied keys  ← START HERE
+**Objective:** proxies load a persistent Ed25519 identity from an **encrypted keystore** instead of minting a new key every boot. KEK comes from a secret separate from the DB.
+
+- **Files:** [trust-agent/src/crypto.ts](../trust-agent/src/crypto.ts) (add keystore fns), [Bank-A/proxy/src/server.ts:34](../Bank-A/proxy/src/server.ts#L34), [Bank-B/proxy/src/server.ts:84](../Bank-B/proxy/src/server.ts#L84).
+- **Tasks:**
+  1. Stand up Vitest in `trust-agent/` (and a shared config the proxies can reuse).
+  2. Add `loadOrCreateKeyPair(kid, keystorePath, kek): Promise<KeyPair>`: if the keystore file exists, decrypt & load; else generate, encrypt, persist, return. Encryption: AES-256-GCM over the 32-byte private key, KEK from env (`KEYSTORE_KEK`), random IV, authenticated. Store `{ kid, publicKey(hex), iv, ciphertext, tag }` as JSON.
+  3. Replace `generateKeyPair(PROXY_KID)` at both proxy boots with `loadOrCreateKeyPair(...)`, reading `KEYSTORE_PATH` and `KEYSTORE_KEK` from env.
+  4. Keystore file path under the existing data volume; **KEK must NOT be derivable from anything the DB admin can read.**
+- **Acceptance criteria:**
+  - Restarting a proxy yields the **same** public key (assert across two `loadOrCreateKeyPair` calls).
+  - Wrong/absent KEK → decryption fails loudly (no silent fallback to a new key).
+  - Private key bytes never appear in logs or in the SQLite DB.
+  - Missing `KEYSTORE_KEK` at boot → process exits with a clear error (fail-fast).
+- **Tests (write first):** same-key-on-reload; tamper-ciphertext → auth failure; wrong-KEK → failure; new keystore created when absent; env-missing → fail-fast.
+- **Residual note:** software keys are a knowingly-accepted compromise (see DISPUTE_HARDENING §5.1). The KEK-isolation requirement is what makes it meaningful — do not shortcut it.
+
+### Delta #2 — Append-only hash-chain
+Add `seq` (monotonic per party) + `prev_hash` to the `envelopes` table; on write, link each row to the previous head; expose a chain-verify function (no gaps, links intact).
+→ [Bank-A/proxy/src/db.ts](../Bank-A/proxy/src/db.ts), [Bank-B/proxy/src/db.ts](../Bank-B/proxy/src/db.ts). Migration must handle existing rows.
+
+### Delta #3 — TrustAgentAI inline co-sign service (new)
+New service co-signing between handshake Phase 2 and Phase 3; maintains its own hash-chain; gates finality. Wire into `ProxyAGateway`.
+
+### Delta #4 — Checkpoint anchoring + heartbeat
+Anchor the per-party chain **HEAD checkpoint** (not an arbitrary signature batch); add a periodic signed on-chain heartbeat publisher for degraded-mode detection.
+→ [Bank-B/merkle-anchor/app/accounting_agent.py](../Bank-B/merkle-anchor/app/accounting_agent.py), [infra/notary.py](../Bank-B/merkle-anchor/infra/notary.py), [domain/merkle.py](../Bank-B/merkle-anchor/domain/merkle.py).
+
+### Delta #5 — WORM content store + envelope-encryption
+Persist plaintext args/output as encrypted, content-addressed blobs (per-tx DEK); cross-push to TrustAgentAI + client; bind content hash into the chain. Today these are *"hashed, NOT stored"* ([envelopes.ts:23](../trust-agent/src/envelopes.ts#L23)).
+
+### Delta #6 — Key-transparency registry
+Replace mutable `register-peer-key` with an append-only, anchored registry: validity windows, revocation-as-append, rotations endorsed by the prior key.
+→ [Bank-A/proxy/src/key-exchange.ts](../Bank-A/proxy/src/key-exchange.ts).
+
+### Delta #7 — Degraded-mode discipline
+Heartbeat-gap detection, reconciliation window (co-sign within N or auto-flag invalid), value/rate cap on degraded transactions.
+
+## 6. Definition of done (whole program)
+
+An external auditor can run all five checks and any tamper/deletion/fabrication/suppression breaks at least one:
+
+1. **Content** — WORM blob `sha256` matches the envelope commitment.
+2. **Envelope** — Ed25519 verifies under the key the registry shows valid *at that timestamp*.
+3. **Continuity** — `prev_hash` links unbroken; no `seq` gaps between anchored checkpoints.
+4. **Anchor** — checkpoint HEAD on Base Sepolia; heartbeat sequence intact around tx time.
+5. **Witness** — inline TrustAgentAI co-signature present (or a valid, capped, reconciled degraded record).
+
+## 7. Handoff status
+
+- Design: **accepted** (this doc + DISPUTE_HARDENING.md).
+- Code: **not started.** Next action = Delta #1 on branch `feat/delta-1-durable-keys`.


### PR DESCRIPTION
## Summary
- `docs/DISPUTE_HARDENING.md` — design decision record for making dispute packs tamper-evident against a colluding-banks threat model (11 resolved decisions, defense-in-depth map, residual risks, delta backlog) plus an investor-facing pitch block.
- `docs/execution_plan.md` — cold-start handoff for another agent/model to execute the deltas: repo orientation, TDD working agreement, ordered delta backlog (starting with durable key custody), definition of done.

No code changes — documentation only, no breaking changes.

## Test plan
- [x] Docs only, no runtime code touched
- [x] Internal relative links verified against current file paths (Bank-A/proxy/src/server.ts, trust-agent/src/crypto.ts, trust-agent/src/envelopes.ts, Bank-B/merkle-anchor/*)