### PR TITLE
feat: Delta #1 — durable, custodied proxy keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
 RPC_URL=https://base-sepolia.g.alchemy.com/v2/YOUR_API_KEY
 PRIVATE_KEY=your_burner_wallet_private_key_here
+
+# 32-byte (64 hex char) key-encryption-keys for the proxy identity keystores.
+# Generate with: openssl rand -hex 32
+# Must live in a secret separate from the DB — never the same store a DB admin can read.
+BANK_A_KEYSTORE_KEK=replace_with_64_hex_chars
+BANK_B_KEYSTORE_KEK=replace_with_64_hex_chars

--- a/Bank-A/proxy/src/server.ts
+++ b/Bank-A/proxy/src/server.ts
@@ -2,7 +2,7 @@ import express from "express";
 import cors from "cors";
 import { createHash, randomUUID } from "crypto";
 import {
-  generateKeyPair,
+  loadOrCreateKeyPair,
   ProxyAGateway,
   buildContentProvenanceReceipt,
   sha256Json,
@@ -25,13 +25,18 @@ import { registerWithProxyB } from "./key-exchange.js";
 const PORT = Number(process.env.PORT ?? 3001);
 const PROXY_B_URL = process.env.PROXY_B_URL ?? "http://bank-b-proxy:3002";
 const DB_PATH = process.env.DB_PATH ?? "/data/bank-a.db";
+const KEYSTORE_PATH = process.env.KEYSTORE_PATH ?? "/data/bank-a-keystore.json";
+const KEYSTORE_KEK = process.env.KEYSTORE_KEK;
 const INITIATOR_DID = "did:workload:bank-a-agent";
 const PROXY_KID = "did:workload:bank-a-proxy#key-1";
 
 let triggered = false;
 
 async function main(): Promise<void> {
-  const proxyKey = await generateKeyPair(PROXY_KID);
+  if (!KEYSTORE_KEK) {
+    throw new Error("KEYSTORE_KEK env var is required to load/create the proxy identity keystore");
+  }
+  const proxyKey = await loadOrCreateKeyPair(PROXY_KID, KEYSTORE_PATH, KEYSTORE_KEK);
 
   try {
     const BANK_A_DID = "did:workload:bank-a-proxy";

--- a/Bank-B/proxy/src/server.ts
+++ b/Bank-B/proxy/src/server.ts
@@ -2,13 +2,14 @@ import express from "express";
 import cors from "cors";
 import { createHash } from "crypto";
 import {
-  generateKeyPair,
+  loadOrCreateKeyPair,
   ProxyBGateway,
   DAGLedger,
   NonceRegistry,
   RiskBudgetEngine,
   type IntentEnvelope,
   type ExecutionEnvelope,
+  type KeyPair,
   signEnvelope,
 } from "@trustagentai/a2a-core";
 import { 
@@ -29,6 +30,8 @@ import { SseBus } from "./sse.js";
 
 const PORT = Number(process.env.PORT ?? 3002);
 const DB_PATH = process.env.DB_PATH ?? "/data/bank-b.db";
+const KEYSTORE_PATH = process.env.KEYSTORE_PATH ?? "/data/bank-b-keystore.json";
+const KEYSTORE_KEK = process.env.KEYSTORE_KEK;
 const PROXY_KID = "did:workload:bank-b-proxy#key-1";
 const BANK_A_DID = "did:workload:bank-a-agent";
 const ANCHOR_URL = process.env.ANCHOR_URL ?? "http://bank-b-anchor:5001";
@@ -57,7 +60,7 @@ let nonceRegistry: NonceRegistry;
 let budgetEngine: RiskBudgetEngine;
 let proxyB: ProxyBGateway;
 
-function initProxyB(proxyBKey: Awaited<ReturnType<typeof generateKeyPair>>, proxyAPublicKeys: Map<string, Uint8Array>) {
+function initProxyB(proxyBKey: KeyPair, proxyAPublicKeys: Map<string, Uint8Array>) {
   ledger = new DAGLedger();
   nonceRegistry = new NonceRegistry();
   budgetEngine = new RiskBudgetEngine();
@@ -81,7 +84,10 @@ function initProxyB(proxyBKey: Awaited<ReturnType<typeof generateKeyPair>>, prox
 }
 
 async function main(): Promise<void> {
-  const proxyKey = await generateKeyPair(PROXY_KID);
+  if (!KEYSTORE_KEK) {
+    throw new Error("KEYSTORE_KEK env var is required to load/create the proxy identity keystore");
+  }
+  const proxyKey = await loadOrCreateKeyPair(PROXY_KID, KEYSTORE_PATH, KEYSTORE_KEK);
   initDb(DB_PATH);
   const sseBus = new SseBus();
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ services:
       PORT: "3002"
       DB_PATH: "/data/bank-b.db"
       ANCHOR_URL: "http://bank-b-anchor:5001"
+      KEYSTORE_PATH: "/data/bank-b-keystore.json"
+      KEYSTORE_KEK: "${BANK_B_KEYSTORE_KEK}"
     volumes:
       - bank-b-data:/data
     healthcheck:
@@ -45,6 +47,8 @@ services:
       PORT: "3001"
       PROXY_B_URL: "http://bank-b-proxy:3002"
       DB_PATH: "/data/bank-a.db"
+      KEYSTORE_PATH: "/data/bank-a-keystore.json"
+      KEYSTORE_KEK: "${BANK_A_KEYSTORE_KEK}"
     volumes:
       - bank-a-data:/data
     depends_on:

--- a/docs/testing/E2E_ANTIGRAVITY_PROMPT.md
+++ b/docs/testing/E2E_ANTIGRAVITY_PROMPT.md
@@ -1,0 +1,204 @@
+# E2E Test Prompt — Gemini 3.5 (Antigravity)
+
+**Purpose:** hand this whole file to Gemini 3.5 in Antigravity as its task prompt. It drives a full local `docker-compose` stack, forces one real transaction all the way to a Base Sepolia on-chain anchor, and verifies every hop: proxy identity durability, DB persistence, signature validity, Merkle proof, and the on-chain tx itself.
+
+**Repo:** `/home/ikarin/Trust-Agent` · **Branch to test:** `feat/delta-1-durable-keys` (contains Delta #1 — durable, custodied proxy keys — from `docs/execution_plan.md`; not yet merged to `main`).
+
+Copy everything below the `---` into Antigravity as-is.
+
+---
+
+## Role
+
+You are a QA/verification agent. Your job is to **run, observe, and report** — not to fix bugs or refactor code. If something fails, capture the exact evidence (logs, curl output, sqlite rows) and report it; do not silently patch it and re-run unless the task explicitly says so. Do not `git push`, `git merge`, or touch `main`. Do not modify `.env`.
+
+## Context you need
+
+- This is `TrustAgentAI` — a cryptographic accountability layer for AI-agent-to-agent payments (`docs/execution_plan.md`, `docs/DISPUTE_HARDENING.md` have the full design; skim them before starting, do not re-litigate the decisions in them).
+- Three-phase protocol per transaction: **IntentEnvelope** (Proxy A signs) → **AcceptanceReceipt** (Proxy B signs) → **ExecutionEnvelope** (Proxy B signs after execution). All three share a `trace_id`.
+- Bank-B batches executed envelopes and anchors the Merkle root of the batch to **Base Sepolia** (chain id 84532) as a 0-ETH self-transaction with the root in `data`. This anchoring path already exists and is *not* part of Delta #1 — you are exercising it end-to-end, not testing new anchor code.
+- **Delta #1 (what's new on this branch):** proxies used to mint a fresh Ed25519 key every boot. Now each proxy loads a persistent identity from an **encrypted keystore file** (AES-256-GCM), with the decryption key (`KEYSTORE_KEK`) coming from an env var separate from the database. Your job includes proving this actually survives a restart and fails loudly on a bad key — that's the acceptance criteria for this delta.
+
+## Pre-flight (do this first, stop and report if any of these fail)
+
+1. `cd /home/ikarin/Trust-Agent && git status` — confirm branch is `feat/delta-1-durable-keys` and the tree is clean. If not on that branch, `git checkout feat/delta-1-durable-keys` (do not create commits).
+2. Confirm `.env` exists and has **all** of: `RPC_URL`, `PRIVATE_KEY`, `BANK_A_KEYSTORE_KEK`, `BANK_B_KEYSTORE_KEK` (all already present as of this writing — just verify, don't print the values). `ANTHROPIC_API_KEY` is **not required**: agents default to local Ollama (`AGENT_MODEL_ID=ollama/qwen3.5:9b` for Bank-A, `ollama/qwen3.6:27b` for Bank-B).
+3. Confirm local Ollama is reachable and has both default models pulled:
+   ```bash
+   curl -s http://localhost:11434/api/tags | grep -o '"name":"[^"]*"'
+   ```
+   Must show `qwen3.5:9b` and `qwen3.6:27b` (or override `AGENT_MODEL_ID`/`OLLAMA_BASE_URL` in your shell env before compose-up if you use different tags — do not edit `.env`).
+4. Confirm the Base Sepolia burner wallet (`PRIVATE_KEY`) has gas. You don't have the address directly — derive and check it from inside the anchor container after step "Startup" below (command given there). If balance is 0, **do not attempt to fund it yourself** — report it and stop before the anchoring step; everything else in this test can still run.
+5. Confirm ports 3000–3002, 4001–4002, 5001 are free on the host.
+
+## Startup
+
+```bash
+cd /home/ikarin/Trust-Agent
+docker compose up --build -d
+docker compose ps
+```
+
+Wait for all services to report healthy (`bank-a-proxy`, `bank-b-proxy` have healthchecks; poll `docker compose ps` or `docker inspect --format '{{.State.Health.Status}}' bank-a-proxy bank-b-proxy` until both are `healthy`, timeout ~90s).
+
+Check every node is actually up:
+```bash
+curl -sf http://localhost:3001/health   # bank-a-proxy
+curl -sf http://localhost:3002/health   # bank-b-proxy
+curl -sf http://localhost:4001/health   # bank-a-agent
+curl -sf http://localhost:4002/health   # bank-b-agent
+curl -sf http://localhost:5001/health   # bank-b-anchor (merkle notary)
+curl -sf http://localhost:3000/         # frontend
+```
+All must return success. Report any that don't, with `docker compose logs <service> --tail 50`.
+
+Derive the anchor wallet address and check its Base Sepolia balance (uses the anchor container's already-installed `web3`/`eth_account`):
+```bash
+docker compose exec bank-b-anchor python3 -c "
+from eth_account import Account
+import os
+addr = Account.from_key(os.environ['PRIVATE_KEY']).address
+print(addr)
+"
+# then, with $RPC_URL from your shell / .env:
+curl -s -X POST "$RPC_URL" -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["<ADDR_FROM_ABOVE>","latest"]}'
+```
+If the hex balance is `0x0`, note it clearly in the final report — the on-chain anchor step will fail with no gas, and that's an environment issue, not a code bug. (Base Sepolia faucet: report the address to the user; do not attempt to acquire funds yourself.)
+
+## Part 1 — Prove key durability (Delta #1 acceptance criteria)
+
+1. Capture each proxy's current public key. The cleanest source is the `register-peer-key` call Bank-A makes to Bank-B at boot — grep the startup logs:
+   ```bash
+   docker compose logs bank-a-proxy | grep -i "key-exchange\|register"
+   docker compose logs bank-b-proxy | grep -i "register-peer-key"
+   ```
+   Also confirm the keystore files exist on the volumes and are **not plaintext**:
+   ```bash
+   docker compose exec bank-a-proxy cat /data/bank-a-keystore.json
+   docker compose exec bank-b-proxy cat /data/bank-b-keystore.json
+   ```
+   Each must be JSON `{ kid, publicKey, iv, ciphertext, tag }` — record the `publicKey` hex value from each. `ciphertext` must **not** decode to anything resembling a raw 32-byte key pattern you can eyeball as plausible plaintext (it's encrypted, this is just a sanity look).
+
+2. Restart both proxies (not a full stack rebuild — this must reuse the same volumes, so it exercises the *load* path, not first-boot *create*):
+   ```bash
+   docker compose restart bank-a-proxy bank-b-proxy
+   ```
+   Wait for both to be `healthy` again, then re-extract the `publicKey` from each keystore file the same way as step 1.
+
+   **PASS criterion:** both `publicKey` values are byte-for-byte identical before and after restart. **FAIL** = any code that regenerates a key on restart is broken — flag as CRITICAL, do not proceed to blame Part 2/3 results on it, since a rotating identity would make every downstream signature check meaningless.
+
+3. Confirm private key material never appears in logs or the DB, anywhere:
+   ```bash
+   docker compose logs bank-a-proxy bank-b-proxy | grep -iE "privateKey|private_key"
+   docker compose exec bank-a-proxy sh -c "strings /data/bank-a.db | grep -i privatekey" || true
+   docker compose exec bank-b-proxy sh -c "strings /data/bank-b.db | grep -i privatekey" || true
+   ```
+   All three must return nothing. If anything matches, capture the exact line as CRITICAL.
+
+4. (Optional but valuable — isolated, does not affect the running stack) Re-run the automated proof of wrong-KEK / malformed-KEK / tampered-ciphertext behavior that's already unit-tested on this branch, to confirm it still holds on this checkout:
+   ```bash
+   cd /home/ikarin/Trust-Agent/trust-agent && npm test && npm run test:coverage
+   ```
+   Record the pass count and coverage numbers in your report.
+
+## Part 2 — Drive one real transaction end-to-end
+
+1. Open SSE streams so you can watch events live (run in background / separate terminal, or poll `GET /events` with `curl -N` for a bounded time window):
+   ```bash
+   curl -N http://localhost:3001/events &
+   curl -N http://localhost:3002/events &
+   ```
+
+2. Fire the demo trigger (this makes `bank-a-agent` run its autonomous scenario loop, which calls tools through Proxy A → Proxy B):
+   ```bash
+   curl -sf -X POST http://localhost:3001/trigger
+   ```
+
+3. Watch `docker compose logs -f bank-a-agent bank-b-agent bank-a-proxy bank-b-proxy` for ~30–60s. You're looking for at least one full Intent → Accept → Execute cycle. Capture a `trace_id` from the logs or from:
+   ```bash
+   curl -s http://localhost:3001/envelopes | python3 -m json.tool | head -60
+   ```
+
+4. Confirm the agent loop finished:
+   ```bash
+   curl -s http://localhost:3001/trigger-status   # expect {"triggered": false} once done
+   ```
+
+## Part 3 — Verify DB persistence
+
+**Known API asymmetry (not a Delta #1 regression, don't re-report it):** Bank-B exposes `GET /envelopes-by-trace/:traceId`; Bank-A does not — it only has `GET /envelopes` (all rows) and uses `getEnvelopesByTraceId` internally inside `/cross-check`, with no route exposing it directly. Use the per-bank commands below as-is.
+
+Bank-A (filter the full list client-side — there is no per-trace route):
+```bash
+curl -s "http://localhost:3001/envelopes" | python3 -c "
+import json,sys
+rows = [e for e in json.load(sys.stdin) if e.get('trace_id') == '<TRACE_ID>']
+print(json.dumps(rows, indent=2))
+"
+```
+Bank-B (per-trace route exists):
+```bash
+curl -s "http://localhost:3002/envelopes-by-trace/<TRACE_ID>" | python3 -m json.tool
+```
+Then confirm the same rows exist directly in SQLite (not just via the API — this is the point of the check). The `envelopes` table schema is `(id TEXT PRIMARY KEY, type TEXT, trace_id TEXT, raw_payload TEXT, signature TEXT, created_at TEXT)`:
+```bash
+docker compose exec bank-a-proxy sh -c "apk add --no-cache sqlite 2>/dev/null; sqlite3 /data/bank-a.db \"SELECT id, type, trace_id, created_at FROM envelopes WHERE trace_id='<TRACE_ID>';\""
+docker compose exec bank-b-proxy sh -c "apk add --no-cache sqlite 2>/dev/null; sqlite3 /data/bank-b.db \"SELECT id, type, trace_id, created_at FROM envelopes WHERE trace_id='<TRACE_ID>';\""
+```
+(If `sqlite3` CLI isn't available and `apk add` fails because the base image isn't Alpine, instead copy the DB out and inspect on the host: `docker cp bank-b-proxy:/data/bank-b.db ./bank-b.db.tmp && sqlite3 ./bank-b.db.tmp "..."`.)
+
+**PASS criterion:** rows exist on both sides for the same `trace_id`, `raw_payload` is present and non-empty, and re-verifying each envelope's signature succeeds:
+```bash
+curl -s "http://localhost:3002/verify-trace/<TRACE_ID>" | python3 -m json.tool
+```
+
+## Part 4 — Force the on-chain anchor and verify it for real
+
+1. Trigger an immediate anchor of whatever's pending (don't wait for the auto-batch threshold):
+   ```bash
+   curl -sf -X POST http://localhost:3002/anchor-now
+   ```
+2. Poll until it's confirmed:
+   ```bash
+   curl -s http://localhost:3002/anchors | python3 -m json.tool
+   ```
+   Look for an entry with `status` no longer `PENDING`, and a populated `tx_hash` + `block_number`.
+3. Verify the transaction actually landed on Base Sepolia, independent of this app's own DB:
+   ```bash
+   curl -s -X POST "$RPC_URL" -H 'content-type: application/json' \
+     -d '{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionReceipt","params":["<TX_HASH>"]}' | python3 -m json.tool
+   ```
+   `status` must be `"0x1"`. Also note the link `https://sepolia.basescan.org/tx/<TX_HASH>` in your report (no need to screenshot it — the RPC receipt is sufficient evidence).
+4. Verify the Merkle proof for the transaction you drove in Part 2 reconciles against that anchored root:
+   ```bash
+   curl -s "http://localhost:3002/verify/<TX_HASH>" | python3 -m json.tool
+   ```
+   Confirm the response indicates the proof is valid for your `trace_id`'s leaf.
+
+## Part 5 — Dispute pack sanity check
+
+```bash
+curl -s "http://localhost:3002/dispute/<id — see /dispute/:id route in Bank-B/proxy/src/server.ts>" | python3 -m json.tool
+```
+Confirm it returns a coherent bundle (envelopes + Merkle proof) for the transaction you drove, and that `args`/`output` fields are hashes only, not raw plaintext (that's expected/by-design for this stage — Delta #5 is what would change it, not in scope here).
+
+## Cleanup
+
+```bash
+docker compose down
+```
+Do **not** remove volumes (`docker compose down -v`) unless explicitly told to — they hold the keystore files whose durability you just proved.
+
+## Report format
+
+Produce a single markdown report with:
+
+1. **Pre-flight** — pass/fail per check in that section, wallet address + balance found.
+2. **Key durability (Delta #1)** — public keys before/after restart (must match), keystore file shape, log/DB grep results for leaked private key material, unit test pass count + coverage.
+3. **Transaction flow** — the `trace_id` used, timestamps of each phase, envelope IDs.
+4. **DB persistence** — row counts/contents from both banks' SQLite, signature re-verification result.
+5. **On-chain anchor** — `tx_hash`, `block_number`, RPC receipt status, Merkle proof verification result, Basescan link.
+6. **Dispute pack** — confirm retrievable and internally consistent.
+7. **Overall verdict** — PASS/FAIL per section, and an explicit note that this run validates Delta #1 (key custody) plus the pre-existing anchor pipeline; it does **not** exercise Deltas #2–7 (hash-chain, inline co-signer, checkpoint/heartbeat, WORM content store, key-transparency, degraded-mode) since those aren't implemented yet — say so plainly rather than implying broader coverage than what ran.
+8. Any CRITICAL findings called out at the very top, before the section-by-section detail.

--- a/trust-agent/CLAUDE.md
+++ b/trust-agent/CLAUDE.md
@@ -8,12 +8,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 npm install           # install dependencies
 npm run build         # compile TypeScript → dist/
 npm run build:check   # type-check without emitting
+npm test              # run Vitest unit tests (src/**/*.test.ts)
+npm run test:coverage # run Vitest with coverage (80% threshold)
 npm run example       # run full A2A lifecycle demo (example.ts)
 npm run proxy:test    # run 4-scenario integration test (proxy-test.ts)
 npm run proxy:server  # start Proxy B HTTP server on PORT (default 3001)
 ```
 
-There is no test framework. `example.ts` and `proxy-test.ts` are the integration tests; run them with `tsx` via the npm scripts above. `tsconfig.json` excludes these files from the build — only `src/**/*` is compiled into `dist/`.
+Unit tests use Vitest (`vitest.config.ts`), colocated as `src/*.test.ts`. `example.ts` and `proxy-test.ts` remain separate integration tests, run with `tsx` via the npm scripts above. `tsconfig.json` excludes these files (and `*.test.ts`) from the build — only `src/**/*` is compiled into `dist/`.
 
 The package is ESM (`"type": "module"`), targets ES2022, and uses `NodeNext` module resolution. All internal imports must use `.js` extensions (TypeScript's NodeNext requirement).
 

--- a/trust-agent/package-lock.json
+++ b/trust-agent/package-lock.json
@@ -16,11 +16,73 @@
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/uuid": "^10.0.0",
+        "@vitest/coverage-v8": "^4.1.9",
         "ts-node": "^10.9.2",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.9"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -34,6 +96,40 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -64,6 +160,25 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@noble/ed25519": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.3.0.tgz",
@@ -72,6 +187,287 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
@@ -101,6 +497,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -117,6 +549,150 @@
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -151,6 +727,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/canonicalize": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
@@ -160,12 +769,39 @@
         "canonicalize": "bin/canonicalize.js"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/diff": {
       "version": "4.0.4",
@@ -177,12 +813,658 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -228,6 +1510,14 @@
         }
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -269,6 +1559,191 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/trust-agent/package.json
+++ b/trust-agent/package.json
@@ -45,6 +45,8 @@
   "scripts": {
     "build": "tsc",
     "build:check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "prepublishOnly": "npm run build",
     "example": "node --loader ts-node/esm example.ts",
     "proxy:test": "node --loader ts-node/esm proxy-test.ts",
@@ -83,7 +85,9 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/uuid": "^10.0.0",
+    "@vitest/coverage-v8": "^4.1.9",
+    "ts-node": "^10.9.2",
     "typescript": "^5.0.0",
-    "ts-node": "^10.9.2"
+    "vitest": "^4.1.9"
   }
 }

--- a/trust-agent/src/crypto.test.ts
+++ b/trust-agent/src/crypto.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  loadOrCreateKeyPair,
+  generateKeyPair,
+  computeEnvelopeHash,
+  sha256Json,
+  sha256,
+  signEnvelope,
+  verifySignature,
+  generateNonce,
+} from "./crypto.js";
+
+const KID = "did:workload:test-proxy#key-1";
+const KEK = "0".repeat(64); // 32-byte hex KEK
+
+describe("loadOrCreateKeyPair", () => {
+  let dir: string;
+  let keystorePath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "keystore-test-"));
+    keystorePath = join(dir, "keystore.json");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("creates a keystore file when none exists", async () => {
+    const keyPair = await loadOrCreateKeyPair(KID, keystorePath, KEK);
+    expect(keyPair.kid).toBe(KID);
+    expect(keyPair.publicKey.length).toBe(32);
+    expect(keyPair.privateKey.length).toBe(32);
+
+    const raw = JSON.parse(readFileSync(keystorePath, "utf8"));
+    expect(raw.kid).toBe(KID);
+    expect(raw.publicKey).toBe(Buffer.from(keyPair.publicKey).toString("hex"));
+    expect(raw.iv).toBeTypeOf("string");
+    expect(raw.ciphertext).toBeTypeOf("string");
+    expect(raw.tag).toBeTypeOf("string");
+    // private key bytes must never appear in plaintext anywhere in the file
+    const privHex = Buffer.from(keyPair.privateKey).toString("hex");
+    expect(raw.ciphertext).not.toBe(privHex);
+  });
+
+  it("returns the same public key across reloads (survives restart)", async () => {
+    const first = await loadOrCreateKeyPair(KID, keystorePath, KEK);
+    const second = await loadOrCreateKeyPair(KID, keystorePath, KEK);
+    expect(Buffer.from(second.publicKey).toString("hex")).toBe(
+      Buffer.from(first.publicKey).toString("hex")
+    );
+    expect(Buffer.from(second.privateKey).toString("hex")).toBe(
+      Buffer.from(first.privateKey).toString("hex")
+    );
+  });
+
+  it("throws GCM auth failure when ciphertext is tampered", async () => {
+    await loadOrCreateKeyPair(KID, keystorePath, KEK);
+    const raw = JSON.parse(readFileSync(keystorePath, "utf8"));
+    const tamperedByte = ((parseInt(raw.ciphertext.slice(0, 2), 16) ^ 0xff) & 0xff)
+      .toString(16)
+      .padStart(2, "0");
+    raw.ciphertext = tamperedByte + raw.ciphertext.slice(2);
+    writeFileSync(keystorePath, JSON.stringify(raw));
+
+    await expect(loadOrCreateKeyPair(KID, keystorePath, KEK)).rejects.toThrow();
+  });
+
+  it("throws (does not silently mint a new key) when KEK is wrong", async () => {
+    await loadOrCreateKeyPair(KID, keystorePath, KEK);
+    const wrongKek = "f".repeat(64);
+    await expect(
+      loadOrCreateKeyPair(KID, keystorePath, wrongKek)
+    ).rejects.toThrow();
+  });
+
+  it("rejects a KEK that is not 32 bytes of hex", async () => {
+    await expect(
+      loadOrCreateKeyPair(KID, keystorePath, "too-short")
+    ).rejects.toThrow();
+  });
+});
+
+describe("envelope hashing and signing", () => {
+  it("computeEnvelopeHash excludes signatures and entry_hash", () => {
+    const envelope = { a: 1, signatures: ["x"], entry_hash: "y" };
+    const withoutExtras = computeEnvelopeHash({ a: 1 });
+    expect(computeEnvelopeHash(envelope)).toBe(withoutExtras);
+  });
+
+  it("sha256Json and sha256 are stable and deterministic", () => {
+    expect(sha256Json({ a: 1 })).toBe(sha256Json({ a: 1 }));
+    expect(sha256("hello")).toBe(sha256("hello"));
+    expect(sha256Json({ a: 1 })).not.toBe(sha256Json({ a: 2 }));
+  });
+
+  it("signEnvelope produces a signature verifySignature accepts", async () => {
+    const keyPair = await generateKeyPair("did:workload:signer#key-1");
+    const envelope = { foo: "bar" };
+    const sig = await signEnvelope(envelope, keyPair, "proxy");
+    expect(sig.kid).toBe(keyPair.kid);
+    await expect(
+      verifySignature(envelope, sig, keyPair.publicKey)
+    ).resolves.toBeUndefined();
+  });
+
+  it("verifySignature rejects a tampered envelope", async () => {
+    const keyPair = await generateKeyPair("did:workload:signer#key-1");
+    const sig = await signEnvelope({ foo: "bar" }, keyPair, "proxy");
+    await expect(
+      verifySignature({ foo: "tampered" }, sig, keyPair.publicKey)
+    ).rejects.toThrow();
+  });
+
+  it("verifySignature rejects a signature from the wrong key", async () => {
+    const signer = await generateKeyPair("did:workload:signer#key-1");
+    const other = await generateKeyPair("did:workload:other#key-1");
+    const envelope = { foo: "bar" };
+    const sig = await signEnvelope(envelope, signer, "proxy");
+    await expect(
+      verifySignature(envelope, sig, other.publicKey)
+    ).rejects.toThrow();
+  });
+
+  it("generateNonce returns 16 hex chars (8 random bytes)", () => {
+    const nonce = generateNonce();
+    expect(nonce).toMatch(/^[0-9a-f]{16}$/);
+    expect(generateNonce()).not.toBe(generateNonce());
+  });
+});

--- a/trust-agent/src/crypto.ts
+++ b/trust-agent/src/crypto.ts
@@ -10,7 +10,8 @@
 import * as ed from "@noble/ed25519";
 import _canonicalize = require("canonicalize");
 const canonicalize = (_canonicalize.default ?? _canonicalize) as (input: unknown) => string | undefined;
-import { createHash, randomBytes } from "crypto";
+import { createHash, randomBytes, createCipheriv, createDecipheriv } from "crypto";
+import { existsSync, readFileSync, writeFileSync } from "fs";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -34,6 +35,69 @@ export interface SignatureBlock {
 export async function generateKeyPair(kid: string): Promise<KeyPair> {
   const privateKey = ed.utils.randomPrivateKey();
   const publicKey = await ed.getPublicKeyAsync(privateKey);
+  return { privateKey, publicKey, kid };
+}
+
+// ─── Durable, Custodied Keystore ───────────────────────────────────────────────
+
+interface KeystoreFile {
+  kid: string;
+  publicKey: string;   // hex
+  iv: string;           // hex, 12 bytes
+  ciphertext: string;   // hex, encrypted 32-byte private key
+  tag: string;           // hex, GCM auth tag
+}
+
+function parseKek(kek: string): Buffer {
+  if (!/^[0-9a-fA-F]{64}$/.test(kek)) {
+    throw new Error("KEYSTORE_KEK must be 64 hex characters (32 bytes)");
+  }
+  return Buffer.from(kek, "hex");
+}
+
+/**
+ * Load an Ed25519 identity from an encrypted keystore file, creating it on
+ * first use. The private key is encrypted at rest with AES-256-GCM under a
+ * KEK supplied by the caller (never derived from anything stored alongside
+ * the keystore, e.g. the database) — a wrong/missing KEK fails loudly rather
+ * than silently minting a new identity.
+ */
+export async function loadOrCreateKeyPair(
+  kid: string,
+  keystorePath: string,
+  kek: string
+): Promise<KeyPair> {
+  const kekBuffer = parseKek(kek);
+
+  if (existsSync(keystorePath)) {
+    const file: KeystoreFile = JSON.parse(readFileSync(keystorePath, "utf8"));
+    const iv = Buffer.from(file.iv, "hex");
+    const tag = Buffer.from(file.tag, "hex");
+    const decipher = createDecipheriv("aes-256-gcm", kekBuffer, iv);
+    decipher.setAuthTag(tag);
+    const privateKey = Buffer.concat([
+      decipher.update(Buffer.from(file.ciphertext, "hex")),
+      decipher.final(),
+    ]);
+    const publicKey = await ed.getPublicKeyAsync(privateKey);
+    return { privateKey: new Uint8Array(privateKey), publicKey, kid: file.kid };
+  }
+
+  const { privateKey, publicKey } = await generateKeyPair(kid);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", kekBuffer, iv);
+  const ciphertext = Buffer.concat([cipher.update(privateKey), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  const file: KeystoreFile = {
+    kid,
+    publicKey: Buffer.from(publicKey).toString("hex"),
+    iv: iv.toString("hex"),
+    ciphertext: ciphertext.toString("hex"),
+    tag: tag.toString("hex"),
+  };
+  writeFileSync(keystorePath, JSON.stringify(file));
+
   return { privateKey, publicKey, kid };
 }
 

--- a/trust-agent/tsconfig.json
+++ b/trust-agent/tsconfig.json
@@ -25,6 +25,7 @@
     "example.ts",
     "proxy-test.ts",
     "src/proxy-server.ts",
-    "src/proxy-test.ts"
+    "src/proxy-test.ts",
+    "src/**/*.test.ts"
   ]
 }

--- a/trust-agent/vitest.config.ts
+++ b/trust-agent/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/crypto.ts"],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Implements Delta #1 from [docs/execution_plan.md](docs/execution_plan.md) (see [docs/DISPUTE_HARDENING.md](docs/DISPUTE_HARDENING.md) for rationale): proxies now load a persistent Ed25519 identity from an encrypted keystore instead of minting a fresh key on every boot.

- Stood up Vitest in `trust-agent/` (`npm test`, `npm run test:coverage`) — this module had no test runner before.
- `trust-agent/src/crypto.ts`: `loadOrCreateKeyPair(kid, keystorePath, kek)` — AES-256-GCM over the 32-byte private key, random IV, authenticated tag. File format: `{ kid, publicKey(hex), iv, ciphertext, tag }`.
- `Bank-A/proxy/src/server.ts`, `Bank-B/proxy/src/server.ts`: replaced `generateKeyPair(PROXY_KID)` with `loadOrCreateKeyPair(...)`, reading `KEYSTORE_PATH`/`KEYSTORE_KEK` from env. Missing `KEYSTORE_KEK` fails fast at boot.
- `docker-compose.yml`: keystore path lives inside the existing `bank-a-data`/`bank-b-data` volumes; KEK comes from `BANK_A_KEYSTORE_KEK`/`BANK_B_KEYSTORE_KEK` — a secret separate from `DB_PATH`.
- `.env.example`: documents the two new KEK placeholders.

## Test plan

- [x] TDD: RED confirmed (`loadOrCreateKeyPair is not a function`) before implementation.
- [x] `npm test` in `trust-agent/` — 11/11 passing (same-key-on-reload, tamper-ciphertext → GCM auth failure, wrong-KEK → failure with no silent fallback, keystore-created-when-absent, malformed-KEK-rejected, plus sanity coverage for previously-untested sign/verify/hash exports).
- [x] `npm run test:coverage` — crypto.ts: 94% stmts / 82% branch / 100% funcs / 100% lines (≥80% gate met).
- [x] `npm run build` green in `trust-agent/`, `Bank-A/proxy/`, `Bank-B/proxy/`.
- [x] Confirmed no `*.test.ts` artifacts leak into `dist/` (tsconfig exclude added).
- [x] Verified private key bytes never appear in proxy logs or SQLite writes (grep across server.ts/db.ts).
- [ ] Not run: full `docker-compose up` end-to-end restart test (would need a live KEK secret + Base Sepolia RPC access) — acceptance criteria verified at the unit level instead.

## Remaining for the next delta

Per [docs/execution_plan.md](docs/execution_plan.md) §5, Delta #2 (append-only hash-chain: `seq` + `prev_hash` in `envelopes` table) is next and depends on this landing.