### PR TITLE
feat: Delta #2 — append-only hash-chain

### DIFF
--- a/Bank-A/proxy/src/db.ts
+++ b/Bank-A/proxy/src/db.ts
@@ -1,4 +1,11 @@
 import Database from "better-sqlite3";
+import {
+  GENESIS_PREV_HASH,
+  computeRowHash,
+  verifyChain,
+  type ChainRow,
+  type ChainVerifyResult,
+} from "@trustagentai/a2a-core";
 
 let db: Database.Database;
 let sseBus: any = null;
@@ -12,7 +19,7 @@ export function initDb(path: string): void {
   // WAL mode for high-concurrency reads/writes without locking
   db.pragma("journal_mode = WAL");
   db.pragma("busy_timeout = 5000");
-  
+
   db.exec(`
     CREATE TABLE IF NOT EXISTS envelopes (
       id TEXT PRIMARY KEY,
@@ -20,7 +27,9 @@ export function initDb(path: string): void {
       trace_id TEXT NOT NULL,
       raw_payload TEXT NOT NULL,
       signature TEXT NOT NULL,
-      created_at TEXT NOT NULL
+      created_at TEXT NOT NULL,
+      seq INTEGER,
+      prev_hash TEXT
     );
     CREATE TABLE IF NOT EXISTS provenance (
       content_hash TEXT PRIMARY KEY,
@@ -35,6 +44,50 @@ export function initDb(path: string): void {
       created_at TEXT NOT NULL
     );
   `);
+
+  backfillChain();
+}
+
+/** Map a raw DB row to the shared ChainRow shape (field names already align). */
+function toChainRow(r: any): ChainRow {
+  return {
+    seq: r.seq,
+    prev_hash: r.prev_hash,
+    id: r.id,
+    type: r.type,
+    trace_id: r.trace_id,
+    raw_payload: r.raw_payload,
+    signature: r.signature,
+    created_at: r.created_at,
+  };
+}
+
+/**
+ * Assign seq + prev_hash to any pre-existing rows that predate Delta #2
+ * (columns added but still NULL). Links them in created_at order so the
+ * historical record becomes a verifiable chain. Idempotent: a no-op once
+ * every row is linked.
+ */
+function backfillChain(): void {
+  const pending = db
+    .prepare("SELECT * FROM envelopes WHERE seq IS NULL ORDER BY created_at ASC")
+    .all() as any[];
+  if (pending.length === 0) return;
+
+  const linked = db.prepare("SELECT * FROM envelopes WHERE seq IS NOT NULL ORDER BY seq DESC LIMIT 1").get() as any;
+  let seq = linked ? linked.seq + 1 : 0;
+  let prevHash = linked ? computeRowHash(toChainRow(linked)) : GENESIS_PREV_HASH;
+
+  const update = db.prepare("UPDATE envelopes SET seq = ?, prev_hash = ? WHERE id = ?");
+  const tx = db.transaction(() => {
+    for (const r of pending) {
+      const row: ChainRow = { ...toChainRow(r), seq, prev_hash: prevHash };
+      update.run(seq, prevHash, r.id);
+      prevHash = computeRowHash(row);
+      seq += 1;
+    }
+  });
+  tx();
 }
 
 export function saveEnvelope(
@@ -45,17 +98,41 @@ export function saveEnvelope(
   signature: string
 ): void {
   const now = new Date().toISOString();
-  db.prepare(
-    "INSERT OR IGNORE INTO envelopes (id, type, trace_id, raw_payload, signature, created_at) VALUES (?, ?, ?, ?, ?, ?)"
-  ).run(id, type, traceId, JSON.stringify(rawPayload), signature, now);
-  
+  const payload = JSON.stringify(rawPayload);
+
+  // Append to the hash-chain atomically: a duplicate id is a no-op and must
+  // not advance the chain (no gap, no re-link).
+  const append = db.transaction(() => {
+    const exists = db.prepare("SELECT 1 FROM envelopes WHERE id = ?").get(id);
+    if (exists) return;
+    const head = db.prepare("SELECT * FROM envelopes ORDER BY seq DESC LIMIT 1").get() as any;
+    const seq = head ? head.seq + 1 : 0;
+    const prevHash = head ? computeRowHash(toChainRow(head)) : GENESIS_PREV_HASH;
+    db.prepare(
+      "INSERT INTO envelopes (id, type, trace_id, raw_payload, signature, created_at, seq, prev_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+    ).run(id, type, traceId, payload, signature, now, seq, prevHash);
+  });
+  append();
+
   // Concurrent SSE broadcast
   sseBus?.broadcast("envelope", { id, type, trace_id: traceId, created_at: now });
-  
+
   // Phase transition trigger
   if (type === "INTENT") {
     sseBus?.broadcast("system-phase", { phase: "RUNNING" });
   }
+}
+
+/** All envelope rows as an ordered chain (seq ascending). */
+export function getChain(): ChainRow[] {
+  return (db
+    .prepare("SELECT * FROM envelopes ORDER BY seq ASC")
+    .all() as any[]).map(toChainRow);
+}
+
+/** Verify the local envelope hash-chain: no seq gaps, prev_hash links intact. */
+export function verifyEnvelopeChain(): ChainVerifyResult {
+  return verifyChain(getChain());
 }
 
 export function getEnvelopes(): unknown[] {

--- a/Bank-A/proxy/src/server.ts
+++ b/Bank-A/proxy/src/server.ts
@@ -18,6 +18,7 @@ import {
   getEnvelopesByTraceId,
   saveThought,
   getThoughts,
+  verifyEnvelopeChain,
 } from "./db.js";
 import { SseBus } from "./sse.js";
 import { registerWithProxyB } from "./key-exchange.js";
@@ -103,6 +104,7 @@ async function main(): Promise<void> {
 
   app.get("/envelopes", (_req, res) => res.json(getEnvelopes()));
   app.get("/thoughts", (_req, res) => res.json(getThoughts()));
+  app.get("/verify-chain", (_req, res) => res.json(verifyEnvelopeChain()));
 
   app.post("/cross-check", async (req, res) => {
     const { traceId } = req.body as { traceId: string };

--- a/Bank-B/proxy/src/db.ts
+++ b/Bank-B/proxy/src/db.ts
@@ -1,4 +1,11 @@
 import Database from "better-sqlite3";
+import {
+  GENESIS_PREV_HASH,
+  computeRowHash,
+  verifyChain,
+  type ChainRow,
+  type ChainVerifyResult,
+} from "@trustagentai/a2a-core";
 
 let db: Database.Database;
 let sseBus: any = null;
@@ -11,7 +18,7 @@ export function initDb(path: string): void {
   db = new Database(path, { timeout: 5000 });
   db.pragma("journal_mode = WAL");
   db.pragma("busy_timeout = 5000");
-  
+
   db.exec(`
     CREATE TABLE IF NOT EXISTS envelopes (
       id TEXT PRIMARY KEY,
@@ -19,7 +26,9 @@ export function initDb(path: string): void {
       trace_id TEXT NOT NULL,
       raw_payload TEXT NOT NULL,
       signature TEXT NOT NULL,
-      created_at TEXT NOT NULL
+      created_at TEXT NOT NULL,
+      seq INTEGER,
+      prev_hash TEXT
     );
     CREATE TABLE IF NOT EXISTS anchors (
       batch_id TEXT PRIMARY KEY,
@@ -44,6 +53,50 @@ export function initDb(path: string): void {
       created_at TEXT NOT NULL
     );
   `);
+
+  backfillChain();
+}
+
+/** Map a raw DB row to the shared ChainRow shape (field names already align). */
+function toChainRow(r: any): ChainRow {
+  return {
+    seq: r.seq,
+    prev_hash: r.prev_hash,
+    id: r.id,
+    type: r.type,
+    trace_id: r.trace_id,
+    raw_payload: r.raw_payload,
+    signature: r.signature,
+    created_at: r.created_at,
+  };
+}
+
+/**
+ * Assign seq + prev_hash to any pre-existing rows that predate Delta #2
+ * (columns added but still NULL). Links them in created_at order so the
+ * historical record becomes a verifiable chain. Idempotent: a no-op once
+ * every row is linked.
+ */
+function backfillChain(): void {
+  const pending = db
+    .prepare("SELECT * FROM envelopes WHERE seq IS NULL ORDER BY created_at ASC")
+    .all() as any[];
+  if (pending.length === 0) return;
+
+  const linked = db.prepare("SELECT * FROM envelopes WHERE seq IS NOT NULL ORDER BY seq DESC LIMIT 1").get() as any;
+  let seq = linked ? linked.seq + 1 : 0;
+  let prevHash = linked ? computeRowHash(toChainRow(linked)) : GENESIS_PREV_HASH;
+
+  const update = db.prepare("UPDATE envelopes SET seq = ?, prev_hash = ? WHERE id = ?");
+  const tx = db.transaction(() => {
+    for (const r of pending) {
+      const row: ChainRow = { ...toChainRow(r), seq, prev_hash: prevHash };
+      update.run(seq, prevHash, r.id);
+      prevHash = computeRowHash(row);
+      seq += 1;
+    }
+  });
+  tx();
 }
 
 export function saveEnvelope(
@@ -54,15 +107,39 @@ export function saveEnvelope(
   signature: string
 ): void {
   const now = new Date().toISOString();
-  db.prepare(
-    "INSERT OR IGNORE INTO envelopes (id, type, trace_id, raw_payload, signature, created_at) VALUES (?, ?, ?, ?, ?, ?)"
-  ).run(id, type, traceId, JSON.stringify(rawPayload), signature, now);
-  
+  const payload = JSON.stringify(rawPayload);
+
+  // Append to the hash-chain atomically: a duplicate id is a no-op and must
+  // not advance the chain (no gap, no re-link).
+  const append = db.transaction(() => {
+    const exists = db.prepare("SELECT 1 FROM envelopes WHERE id = ?").get(id);
+    if (exists) return;
+    const head = db.prepare("SELECT * FROM envelopes ORDER BY seq DESC LIMIT 1").get() as any;
+    const seq = head ? head.seq + 1 : 0;
+    const prevHash = head ? computeRowHash(toChainRow(head)) : GENESIS_PREV_HASH;
+    db.prepare(
+      "INSERT INTO envelopes (id, type, trace_id, raw_payload, signature, created_at, seq, prev_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+    ).run(id, type, traceId, payload, signature, now, seq, prevHash);
+  });
+  append();
+
   sseBus?.broadcast("envelope", { id, type, trace_id: traceId, created_at: now });
-  
+
   if (type === "INTENT") {
     sseBus?.broadcast("system-phase", { phase: "RUNNING" });
   }
+}
+
+/** All envelope rows as an ordered chain (seq ascending). */
+export function getChain(): ChainRow[] {
+  return (db
+    .prepare("SELECT * FROM envelopes ORDER BY seq ASC")
+    .all() as any[]).map(toChainRow);
+}
+
+/** Verify the local envelope hash-chain: no seq gaps, prev_hash links intact. */
+export function verifyEnvelopeChain(): ChainVerifyResult {
+  return verifyChain(getChain());
 }
 
 export function getEnvelopes(): unknown[] {

--- a/Bank-B/proxy/src/server.ts
+++ b/Bank-B/proxy/src/server.ts
@@ -24,7 +24,8 @@ import {
   getDisputePackByTraceId,
   saveThought,
   getThoughts,
-  getAnchors
+  getAnchors,
+  verifyEnvelopeChain
 } from "./db.js";
 import { SseBus } from "./sse.js";
 
@@ -171,6 +172,7 @@ async function main(): Promise<void> {
   app.get("/envelopes", (_req, res) => res.json(getEnvelopes()));
   app.get("/thoughts", (_req, res) => res.json(getThoughts()));
   app.get("/anchors", (_req, res) => res.json(getAnchors()));
+  app.get("/verify-chain", (_req, res) => res.json(verifyEnvelopeChain()));
 
   app.get("/dispute/:id", (req, res) => {
     // Try in-memory ledger first, fallback to DB

--- a/docs/testing/E2E_ANTIGRAVITY_PROMPT.md
+++ b/docs/testing/E2E_ANTIGRAVITY_PROMPT.md
@@ -153,6 +153,22 @@ docker compose exec bank-b-proxy sh -c "apk add --no-cache sqlite 2>/dev/null; s
 curl -s "http://localhost:3002/verify-trace/<TRACE_ID>" | python3 -m json.tool
 ```
 
+## Part 3b — Hash-chain continuity (Delta #2)
+
+Each proxy links its envelope rows into an append-only hash-chain (`seq` + `prev_hash`). Verify it holds, then prove tampering/deletion is detectable.
+
+1. Both chains verify clean after the transaction:
+   ```bash
+   curl -s http://localhost:3001/verify-chain | python3 -m json.tool   # expect {"valid": true}
+   curl -s http://localhost:3002/verify-chain | python3 -m json.tool   # expect {"valid": true}
+   ```
+2. Inspect the new columns directly (should be a gapless 0,1,2,… sequence with non-null `prev_hash`):
+   ```bash
+   docker compose exec bank-b-proxy sh -c "sqlite3 /data/bank-b.db 'SELECT seq, substr(prev_hash,1,12), type FROM envelopes ORDER BY seq;'" 2>/dev/null \
+     || (docker cp bank-b-proxy:/data/bank-b.db ./bank-b.db.tmp && sqlite3 ./bank-b.db.tmp "SELECT seq, substr(prev_hash,1,12), type FROM envelopes ORDER BY seq;")
+   ```
+3. **Tamper-detection (do this on the copied `./bank-b.db.tmp`, NOT the live container DB — do not corrupt the running stack):** edit one row's `raw_payload` in the copy, then run the same verify logic against it, or reason from `/verify-chain` semantics. Expected: mutating any row's content breaks its successor's `prev_hash` link; deleting a row opens a `seq` gap — either makes `verifyChain` return `{"valid": false, "error": ...}`. Report whether the break is detected. (You can confirm this deterministically via the unit tests instead: `cd trust-agent && npm test -- hash-chain` — the tamper and gap cases are covered there.)
+
 ## Part 4 — Force the on-chain anchor and verify it for real
 
 1. Trigger an immediate anchor of whatever's pending (don't wait for the auto-batch threshold):

--- a/trust-agent/src/hash-chain.test.ts
+++ b/trust-agent/src/hash-chain.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  GENESIS_PREV_HASH,
+  computeRowHash,
+  verifyChain,
+  type ChainRow,
+} from "./hash-chain.js";
+
+function makeRow(seq: number, prevHash: string, overrides: Partial<ChainRow> = {}): ChainRow {
+  return {
+    seq,
+    prev_hash: prevHash,
+    id: `env-${seq}`,
+    type: "INTENT",
+    trace_id: `trace-${seq}`,
+    raw_payload: `{"n":${seq}}`,
+    signature: `sig-${seq}`,
+    created_at: `2026-07-05T00:00:0${seq}.000Z`,
+    ...overrides,
+  };
+}
+
+/** Build a well-formed linked chain of `n` rows starting at seq 0. */
+function buildChain(n: number): ChainRow[] {
+  const rows: ChainRow[] = [];
+  let prev = GENESIS_PREV_HASH;
+  for (let i = 0; i < n; i++) {
+    const row = makeRow(i, prev);
+    rows.push(row);
+    prev = computeRowHash(row);
+  }
+  return rows;
+}
+
+describe("computeRowHash", () => {
+  it("is deterministic for identical input", () => {
+    const row = makeRow(0, GENESIS_PREV_HASH);
+    expect(computeRowHash(row)).toBe(computeRowHash({ ...row }));
+  });
+
+  it("changes when any committed field changes", () => {
+    const row = makeRow(0, GENESIS_PREV_HASH);
+    const base = computeRowHash(row);
+    expect(computeRowHash({ ...row, raw_payload: '{"n":999}' })).not.toBe(base);
+    expect(computeRowHash({ ...row, signature: "tampered" })).not.toBe(base);
+    expect(computeRowHash({ ...row, seq: 1 })).not.toBe(base);
+    expect(computeRowHash({ ...row, prev_hash: "f".repeat(64) })).not.toBe(base);
+  });
+
+  it("returns a 64-char hex digest", () => {
+    expect(computeRowHash(makeRow(0, GENESIS_PREV_HASH))).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("verifyChain", () => {
+  it("accepts an empty chain (vacuously valid)", () => {
+    expect(verifyChain([]).valid).toBe(true);
+  });
+
+  it("accepts a well-formed linked chain", () => {
+    const result = verifyChain(buildChain(5));
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("rejects a first row whose prev_hash is not genesis", () => {
+    const rows = buildChain(3);
+    rows[0] = { ...rows[0], prev_hash: "a".repeat(64) };
+    const result = verifyChain(rows);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/genesis/i);
+  });
+
+  it("rejects a seq gap between rows", () => {
+    const rows = buildChain(4);
+    // drop the row at seq 2 -> gap
+    const withGap = [rows[0], rows[1], rows[3]];
+    const result = verifyChain(withGap);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/seq/i);
+  });
+
+  it("rejects tampered row content (broken prev_hash link)", () => {
+    const rows = buildChain(4);
+    // mutate the payload of row 1 without recomputing downstream links
+    rows[1] = { ...rows[1], raw_payload: '{"n":666}' };
+    const result = verifyChain(rows);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/prev_hash|link/i);
+  });
+
+  it("rejects an out-of-order / non-monotonic seq", () => {
+    const rows = buildChain(3);
+    const reordered = [rows[0], rows[2], rows[1]];
+    expect(verifyChain(reordered).valid).toBe(false);
+  });
+});

--- a/trust-agent/src/hash-chain.ts
+++ b/trust-agent/src/hash-chain.ts
@@ -1,0 +1,79 @@
+/**
+ * TrustAgentAI — Per-party append-only hash-chain
+ *
+ * Each proxy owns one SQLite database = one party. Every persisted envelope
+ * row carries a monotonic `seq` and a `prev_hash` that links it to the prior
+ * row's content hash, forming a tamper-evident chain. Deleting a row leaves a
+ * `seq` gap; editing a row's content breaks the `prev_hash` link of its
+ * successor. See Delta #2 in docs/execution_plan.md.
+ */
+
+import { sha256Json } from "./crypto.js";
+
+/** prev_hash of the first row in a chain (no predecessor). */
+export const GENESIS_PREV_HASH = "0".repeat(64);
+
+/**
+ * The committed fields of a chained envelope row. `prev_hash` and `seq` are
+ * part of the hash so the position in the chain is itself bound.
+ */
+export interface ChainRow {
+  seq: number;
+  prev_hash: string;
+  id: string;
+  type: string;
+  trace_id: string;
+  raw_payload: string;
+  signature: string;
+  created_at: string;
+}
+
+export interface ChainVerifyResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * Deterministic content hash of a chained row (hex SHA-256 over the JCS
+ * canonicalization of its committed fields). This value becomes the next
+ * row's `prev_hash`.
+ */
+export function computeRowHash(row: ChainRow): string {
+  return sha256Json({
+    seq: row.seq,
+    prev_hash: row.prev_hash,
+    id: row.id,
+    type: row.type,
+    trace_id: row.trace_id,
+    raw_payload: row.raw_payload,
+    signature: row.signature,
+    created_at: row.created_at,
+  });
+}
+
+/**
+ * Verify an ordered list of rows forms an unbroken chain:
+ *  - `seq` starts at 0 and increments by exactly 1 (no gaps, no reorder);
+ *  - the first row's `prev_hash` is the genesis value;
+ *  - each row's `prev_hash` equals the recomputed hash of its predecessor.
+ * An empty chain is vacuously valid.
+ */
+export function verifyChain(rows: readonly ChainRow[]): ChainVerifyResult {
+  let expectedPrev = GENESIS_PREV_HASH;
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+
+    if (row.seq !== i) {
+      return { valid: false, error: `seq mismatch at index ${i}: expected ${i}, got ${row.seq}` };
+    }
+    if (row.prev_hash !== expectedPrev) {
+      const reason = i === 0 ? "does not match genesis" : "broken prev_hash link";
+      return { valid: false, error: `prev_hash ${reason} at seq ${row.seq}` };
+    }
+
+    expectedPrev = computeRowHash(row);
+  }
+
+  return { valid: true };
+}

--- a/trust-agent/src/index.ts
+++ b/trust-agent/src/index.ts
@@ -2,6 +2,7 @@
 // Main entry point — re-exports everything consumers need
 
 export * from "./crypto.js";
+export * from "./hash-chain.js";
 export * from "./envelopes.js";
 export * from "./ledger.js";
 export * from "./nonce-registry.js";

--- a/trust-agent/vitest.config.ts
+++ b/trust-agent/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],
-      include: ["src/crypto.ts"],
+      include: ["src/crypto.ts", "src/hash-chain.ts"],
       thresholds: {
         lines: 80,
         functions: 80,


### PR DESCRIPTION
## Summary

Implements Delta #2 from [docs/execution_plan.md](docs/execution_plan.md) §5: each proxy links its `envelopes` rows into a per-party, append-only hash-chain so deletion/reorder/suppression is provable (Definition-of-Done check #3, continuity).

- **Shared core** ([trust-agent/src/hash-chain.ts](trust-agent/src/hash-chain.ts)): `computeRowHash` (deterministic sha256/JCS over a row's committed fields incl. `seq`+`prev_hash`), `verifyChain` (rejects seq gaps, reorder, non-genesis first link, broken `prev_hash` link), `GENESIS_PREV_HASH`.
- **Both proxies** ([Bank-A/proxy/src/db.ts](Bank-A/proxy/src/db.ts), [Bank-B/proxy/src/db.ts](Bank-B/proxy/src/db.ts)): `envelopes` gains `seq` + `prev_hash`; `saveEnvelope` appends atomically (links to head, `seq = head.seq+1`), duplicate id is a no-op that doesn't advance the chain. `initDb` backfills pre-existing rows in `created_at` order (idempotent).
- New `GET /verify-chain` on each proxy surfaces `verifyChain()` over the local chain.

## Test plan

- [x] TDD on the shared module: RED confirmed (module absent) → GREEN. 9 specs (determinism, field-sensitivity, empty chain, well-formed chain, non-genesis first link, seq gap, tampered content, reorder).
- [x] `npm run test:coverage` in `trust-agent/` — hash-chain.ts **100%**; overall 95% stmts / 87% branch / 100% funcs/lines (≥80% gate met).
- [x] `npm run build` green in `trust-agent/`, `Bank-A/proxy/`, `Bank-B/proxy/`.
- [ ] Full docker-compose E2E not run here — [docs/testing/E2E_ANTIGRAVITY_PROMPT.md](docs/testing/E2E_ANTIGRAVITY_PROMPT.md) Part 3b now covers `/verify-chain` + tamper/gap detection.

## Scope note

The verifiable chain math is unit-tested in `trust-agent`; the per-proxy DB glue (SQL migration, seq assignment) is integration-level, exercised by the E2E prompt rather than a second Vitest harness in the proxy packages. Migration handles existing rows per the delta spec. Wire compat preserved: envelope JSON shape, `signed_digest` rule, and SSE event names unchanged.

Depends on Delta #1 (merged, #18). Next: Delta #3 (TrustAgentAI inline co-sign service).