### PR TITLE
Delta #3 — TrustAgentAI inline co-sign witness service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ PRIVATE_KEY=your_burner_wallet_private_key_here
 # Must live in a secret separate from the DB — never the same store a DB admin can read.
 BANK_A_KEYSTORE_KEK=replace_with_64_hex_chars
 BANK_B_KEYSTORE_KEK=replace_with_64_hex_chars
+
+# Delta #3 — the TrustAgentAI Cloud witness holds its OWN durable key under its
+# OWN KEK, separate from both banks and from the database.
+TRUSTAGENT_KEYSTORE_KEK=replace_with_64_hex_chars

--- a/Bank-A/proxy/src/key-exchange.ts
+++ b/Bank-A/proxy/src/key-exchange.ts
@@ -22,3 +22,34 @@ export async function registerWithProxyB(
   }
   throw new Error("[key-exchange] failed to register with Proxy B after max retries");
 }
+
+/**
+ * Register this proxy's public key with the independent witness (Delta #3) so
+ * the witness can verify our signatures before it will co-sign a transaction.
+ * Best-effort with retries — the witness holds the key registry independently
+ * of both banks.
+ */
+export async function registerWithWitness(
+  witnessUrl: string,
+  kid: string,
+  publicKeyHex: string,
+  retries = 25
+): Promise<void> {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const res = await fetch(`${witnessUrl}/register-key`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kid, publicKeyHex }),
+      });
+      if (res.ok) {
+        console.log("[key-exchange] registered with witness successfully");
+        return;
+      }
+    } catch {
+      // Witness not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error("[key-exchange] failed to register with witness after max retries");
+}

--- a/Bank-A/proxy/src/server.ts
+++ b/Bank-A/proxy/src/server.ts
@@ -21,10 +21,11 @@ import {
   verifyEnvelopeChain,
 } from "./db.js";
 import { SseBus } from "./sse.js";
-import { registerWithProxyB } from "./key-exchange.js";
+import { registerWithProxyB, registerWithWitness } from "./key-exchange.js";
 
 const PORT = Number(process.env.PORT ?? 3001);
 const PROXY_B_URL = process.env.PROXY_B_URL ?? "http://bank-b-proxy:3002";
+const TRUSTAGENT_URL = process.env.TRUSTAGENT_URL;
 const DB_PATH = process.env.DB_PATH ?? "/data/bank-a.db";
 const KEYSTORE_PATH = process.env.KEYSTORE_PATH ?? "/data/bank-a-keystore.json";
 const KEYSTORE_KEK = process.env.KEYSTORE_KEK;
@@ -56,11 +57,22 @@ async function main(): Promise<void> {
   const proxyA = new ProxyAGateway({
     proxyKey,
     proxyBEndpoint: PROXY_B_URL,
+    witnessEndpoint: TRUSTAGENT_URL,
     ttlSeconds: 60,
   });
 
   const publicKeyHex = Buffer.from(proxyKey.publicKey).toString("hex");
   await registerWithProxyB(PROXY_B_URL, PROXY_KID, publicKeyHex);
+
+  // Delta #3: register our key with the independent witness so it can verify
+  // our Intent signature before co-signing (finality gate).
+  if (TRUSTAGENT_URL) {
+    try {
+      await registerWithWitness(TRUSTAGENT_URL, PROXY_KID, publicKeyHex);
+    } catch (e) {
+      console.warn("[key-exchange] witness registration failed", e);
+    }
+  }
 
   const app = express();
   app.use(express.json());
@@ -235,15 +247,24 @@ async function main(): Promise<void> {
         return;
       }
 
-      const { intent_envelope: intent, acceptance_receipt: acceptance, execution_envelope: execution } =
+      const { intent_envelope: intent, acceptance_receipt: acceptance, execution_envelope: execution, cosign_receipt: cosign } =
         mcpResult.result!._a2a!;
 
       saveEnvelope(intent.trace_id + ":intent", "INTENT", intent.trace_id, intent, JSON.stringify(intent.signatures));
       saveEnvelope(acceptance.trace_id + ":acceptance", "ACCEPTANCE", acceptance.trace_id, acceptance, JSON.stringify(acceptance.signatures));
       saveEnvelope(execution.trace_id + ":execution", "EXECUTION", execution.trace_id, execution, JSON.stringify(execution.signatures));
 
+      // Delta #3: persist the independent witness co-signature alongside the
+      // handshake envelopes so it is visible in the dispute pack / UI.
+      if (cosign) {
+        saveEnvelope(cosign.trace_id + ":cosign", "COSIGN", cosign.trace_id, cosign, JSON.stringify(cosign.signatures));
+      }
+
       sseBus.broadcast("envelope", { type: "INTENT", traceId: intent.trace_id, tool, cost, ts });
       sseBus.broadcast("envelope", { type: "ACCEPTANCE", traceId: acceptance.trace_id, ts });
+      if (cosign) {
+        sseBus.broadcast("envelope", { type: "COSIGN", traceId: cosign.trace_id, ts });
+      }
 
       sseBus.broadcast("execution-complete", {
         traceId: execution.trace_id,

--- a/Bank-B/proxy/src/key-exchange.ts
+++ b/Bank-B/proxy/src/key-exchange.ts
@@ -1,0 +1,32 @@
+/**
+ * Register this proxy's public key with the independent witness (Delta #3).
+ *
+ * The witness must verify BOTH the Intent (Proxy A) and the Acceptance
+ * (Proxy B) signatures before it will co-sign. Bank-B therefore registers its
+ * own key with the witness at boot, from a channel the witness controls —
+ * neither bank hands the witness the other's key.
+ */
+export async function registerWithWitness(
+  witnessUrl: string,
+  kid: string,
+  publicKeyHex: string,
+  retries = 25
+): Promise<void> {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const res = await fetch(`${witnessUrl}/register-key`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kid, publicKeyHex }),
+      });
+      if (res.ok) {
+        console.log("[key-exchange] registered with witness successfully");
+        return;
+      }
+    } catch {
+      // Witness not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error("[key-exchange] failed to register with witness after max retries");
+}

--- a/Bank-B/proxy/src/server.ts
+++ b/Bank-B/proxy/src/server.ts
@@ -28,9 +28,11 @@ import {
   verifyEnvelopeChain
 } from "./db.js";
 import { SseBus } from "./sse.js";
+import { registerWithWitness } from "./key-exchange.js";
 
 const PORT = Number(process.env.PORT ?? 3002);
 const DB_PATH = process.env.DB_PATH ?? "/data/bank-b.db";
+const TRUSTAGENT_URL = process.env.TRUSTAGENT_URL;
 const KEYSTORE_PATH = process.env.KEYSTORE_PATH ?? "/data/bank-b-keystore.json";
 const KEYSTORE_KEK = process.env.KEYSTORE_KEK;
 const PROXY_KID = "did:workload:bank-b-proxy#key-1";
@@ -94,6 +96,15 @@ async function main(): Promise<void> {
 
   const proxyAPublicKeys = new Map<string, Uint8Array>();
   initProxyB(proxyKey, proxyAPublicKeys);
+
+  // Delta #3: register our key with the independent witness so it can verify
+  // our Acceptance signature before co-signing. Best-effort in the background.
+  if (TRUSTAGENT_URL) {
+    const pubHex = Buffer.from(proxyKey.publicKey).toString("hex");
+    registerWithWitness(TRUSTAGENT_URL, PROXY_KID, pubHex).catch((e) =>
+      console.warn("[key-exchange] witness registration failed", e)
+    );
+  }
 
   const pendingAnchorTraces = new Set<string>();
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,25 @@
 services:
+  trust-agent-cloud:
+    build:
+      context: .
+      dockerfile: trust-agent-cloud/Dockerfile
+    container_name: trust-agent-cloud
+    ports:
+      - "3003:3003"
+    environment:
+      PORT: "3003"
+      DB_PATH: "/data/trust-agent-cloud.db"
+      KEYSTORE_PATH: "/data/trust-agent-cloud-keystore.json"
+      KEYSTORE_KEK: "${TRUSTAGENT_KEYSTORE_KEK}"
+    volumes:
+      - trust-agent-cloud-data:/data
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3003/health').then(r=>r.ok?process.exit(0):process.exit(1)).catch(()=>process.exit(1))"]
+      interval: 5s
+      timeout: 5s
+      retries: 15
+      start_period: 40s
+
   bank-b-anchor:
     build:
       context: Bank-B/merkle-anchor
@@ -25,10 +46,14 @@ services:
       PORT: "3002"
       DB_PATH: "/data/bank-b.db"
       ANCHOR_URL: "http://bank-b-anchor:5001"
+      TRUSTAGENT_URL: "http://trust-agent-cloud:3003"
       KEYSTORE_PATH: "/data/bank-b-keystore.json"
       KEYSTORE_KEK: "${BANK_B_KEYSTORE_KEK}"
     volumes:
       - bank-b-data:/data
+    depends_on:
+      trust-agent-cloud:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3002/health').then(r=>r.ok?process.exit(0):process.exit(1)).catch(()=>process.exit(1))"]
       interval: 5s
@@ -46,6 +71,7 @@ services:
     environment:
       PORT: "3001"
       PROXY_B_URL: "http://bank-b-proxy:3002"
+      TRUSTAGENT_URL: "http://trust-agent-cloud:3003"
       DB_PATH: "/data/bank-a.db"
       KEYSTORE_PATH: "/data/bank-a-keystore.json"
       KEYSTORE_KEK: "${BANK_A_KEYSTORE_KEK}"
@@ -53,6 +79,8 @@ services:
       - bank-a-data:/data
     depends_on:
       bank-b-proxy:
+        condition: service_healthy
+      trust-agent-cloud:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3001/health').then(r=>r.ok?process.exit(0):process.exit(1)).catch(()=>process.exit(1))"]
@@ -118,3 +146,4 @@ services:
 volumes:
   bank-a-data:
   bank-b-data:
+  trust-agent-cloud-data:

--- a/docs/testing/DELTA_3_KICKOFF_PROMPT.md
+++ b/docs/testing/DELTA_3_KICKOFF_PROMPT.md
@@ -1,0 +1,78 @@
+# Kickoff Prompt — Delta #3 (TrustAgentAI inline co-sign service)
+
+Copy everything below the `---` into a **fresh** Claude Code / coding-agent session started in `/home/ikarin/Trust-Agent`. It is self-contained; the new session starts cold.
+
+---
+
+Ты — coding-агент, продолжаешь работу над проектом **TrustAgentAI** (репо `/home/ikarin/Trust-Agent`).
+
+## Контекст (прочитай ПЕРВЫМ, до любого кода)
+
+1. `docs/execution_plan.md` — план исполнения, ориентация по репо, working agreement, backlog из 7 дельт. **Delta #3 — твоя задача.**
+2. `docs/DISPUTE_HARDENING.md` — threat model и обоснования (особенно §3 «Third witness», §5.2/5.3 про residual risks витнеса).
+3. `docs/testing/E2E_ANTIGRAVITY_PROMPT.md` — как гоняется полный стек локально (пригодится в конце).
+
+Решения в этих доках УЖЕ ПРИНЯТЫ — не переоткрывай. Если считаешь решение ошибочным, подними явно, не меняй курс молча.
+
+## Что уже сделано (Delta #1 и #2 — смерджены в main, ПЕРЕИСПОЛЬЗУЙ, не переизобретай)
+
+- **Delta #1 — durable keys.** В `trust-agent/src/crypto.ts` есть `loadOrCreateKeyPair(kid, keystorePath, kek): Promise<KeyPair>` — грузит Ed25519-идентичность из зашифрованного (AES-256-GCM) keystore, KEK из env, fail-fast при отсутствии KEK. Прокси используют его на бутах, читая `KEYSTORE_PATH`/`KEYSTORE_KEK`. **Новый co-sign сервис ОБЯЗАН взять эту же функцию для своего собственного durable-ключа (ключ витнеса) со своим отдельным KEK — не генерируй ключ на старте.**
+- **Delta #2 — hash-chain.** В `trust-agent/src/hash-chain.ts` есть shared-модуль: `GENESIS_PREV_HASH`, `computeRowHash(row): string`, `verifyChain(rows): {valid, error?}`, тип `ChainRow`. Экспортирован из `@trustagentai/a2a-core`. Прокси-`db.ts` уже сцепляют строки `envelopes` через `seq`+`prev_hash`. **Собственную hash-chain co-sign сервиса стройте НА ЭТОМ ЖЕ модуле — не пишите второй.**
+- **Тест-раннер.** Vitest уже стоит в `trust-agent/` (`npm test`, `npm run test:coverage`, порог покрытия 80% через `vitest.config.ts`, тест-файлы `src/*.test.ts` исключены из tsc-билда). Для нового TS-сервиса подними аналогичный Vitest, если он в отдельном пакете.
+- **Внимание — активный хук GateGuard.** Перед первым Bash и перед каждым Write/Edit среда потребует «fact-forcing»: назвать что делаешь, кто вызывает файл, подтвердить отсутствие дубля, процитировать инструкцию. Это нормально — просто отвечай на 4 пункта и повторяй операцию. При деструктивных командах (`rm -rf`) — отдельное подтверждение.
+
+## Бранч
+
+Ветка `feat/delta-3-cosign` УЖЕ создана от актуального main и запушена. Работай в ней. НЕ коммить в main, НЕ мерджи сам — в конце открой PR.
+
+## Задача — Delta #3 «TrustAgentAI inline co-sign service»
+
+Нужен **новый сервис-витнес**, независимый от обоих банков, который co-подписывает транзакцию **инлайн между Phase 2 и Phase 3** хендшейка, ведёт **собственную append-only hash-chain**, и **гейтит финальность**: транзакция без валидной co-подписи витнеса не считается завершённой. Это и есть «третий независимый ключ» из threat-model (закрывает fabrication при сговоре двух банков).
+
+### Где именно врезаться (точные точки в коде)
+
+Трёхфазный протокол: **IntentEnvelope (Phase 1, Proxy A подписывает)** → **AcceptanceReceipt (Phase 2, Proxy B подписывает)** → **ExecutionEnvelope (Phase 3, Proxy B контр-подписывает)**. Все три связаны `trace_id`.
+
+Оркестратор — `ProxyAGateway.forwardToolCall` в `trust-agent/src/trust-proxy.ts` (~строки 108–200):
+- Шаг 2 (`~L134–149`): POST `/accept` на Proxy B → получает `AcceptanceReceipt`.
+- Шаг 3 (`~L151–159`): выполняет tool.
+- Шаг 4–5 (`~L161–186`): строит ExecutionEnvelope → POST `/executed` на Proxy B → dual-signed receipt.
+
+**Врезка co-sign: между получением AcceptanceReceipt (конец шага 2) и финализацией.** Рекомендация (settled в DISPUTE_HARDENING §3, «inline, before it can complete»): после того как есть Intent+Acceptance, Proxy A вызывает витнес; витнес проверяет обе подписи, co-подписывает дайджест транзакции, аппендит запись в свою hash-chain, возвращает co-signature. Без успешной co-подписи — транзакция не финализируется (в MVP: возвращать MCP-ошибку или деградированную метку; полноценный degraded-mode — это Delta #9, здесь только sync inline path + гейт).
+
+### Что построить
+
+1. **Новый сервис `trust-agent-cloud/`** (или обсуди имя) — отдельный TS/Express-сервис по образцу прокси (ESM, tsconfig NodeNext). Эндпоинт вроде `POST /co-sign`, принимающий `{ intent, acceptance }` (или их дайджесты), возвращающий `{ cosignature, seq, prev_hash }`.
+   - Собственный durable-ключ через `loadOrCreateKeyPair` (Delta #1), свой `KEYSTORE_PATH`/`KEYSTORE_KEK`, отдельный от банков.
+   - Своя SQLite + hash-chain через shared `hash-chain.ts` (Delta #2). Свой `GET /verify-chain`.
+   - `GET /health`.
+2. **Проводка в `ProxyAGateway`**: конфиг получает endpoint витнеса; между Phase 2 и Phase 3 — вызов `/co-sign`; результат приложить в `_a2a` (рядом с intent/acceptance/execution envelopes) и/или в ExecutionEnvelope; при провале co-sign — гейт финальности.
+3. **docker-compose.yml**: новый сервис `trust-agent-cloud` со своим data-volume и `TRUSTAGENT_KEYSTORE_KEK` (env-плейсхолдер в `.env.example`, реальное — в gitignored `.env`). Прокси A получает `TRUSTAGENT_URL`.
+4. **Не ломать wire-compat**: форма JSON-конверта, правило `signed_digest` = `SHA-256(JCS(envelope − signatures))`, имена SSE-событий. Co-подпись — аддитивна.
+
+## Метод — строгий TDD (требование проекта)
+
+RED (падающий тест, убедись что реально падает) → GREEN (минимальная реализация) → REFACTOR. Покрытие ≥80% на новых модулях. Чистая логика (проверка подписей, co-sign, построение звена chain) — в тестируемых модулях `trust-agent/src`; сетевую/SQL-обвязку сервиса покрывай интеграционно.
+
+### Тесты (написать ПЕРВЫМИ)
+- Витнес отвергает запрос, если подпись Intent или Acceptance невалидна.
+- Успешный co-sign: возвращает Ed25519-подпись, проверяемую под durable-ключом витнеса.
+- Co-sign аппендит ровно одно звено в hash-chain витнеса; `verifyChain` остаётся valid; дубликат (тот же trace_id) не двигает цепь / идемпотентен.
+- `ProxyAGateway`: при недоступном/отказавшем витнесе транзакция НЕ финализируется как валидная (гейт срабатывает), а не молча проходит.
+- Ключ витнеса переживает рестарт (тот же public key) — как в Delta #1.
+
+## Acceptance criteria
+- Транзакция без валидной co-подписи витнеса не проходит как финальная.
+- Витнес независим: свой durable-ключ (свой KEK, отдельный от банковских и от БД), своя anchored-ready hash-chain.
+- Байты приватных ключей никогда не в логах/в SQLite.
+- Существующий happy-path (демо через `/trigger` → Intent/Accept/Execute) продолжает работать, теперь с co-подписью в `_a2a`.
+- `npm run build` зелёный в `trust-agent/`, обоих прокси и новом сервисе; тесты зелёные; покрытие ≥80% на новых модулях.
+
+## Ограничения
+- Никаких секретов в исходниках (`.env` gitignored).
+- Иммутабельность, файлы ≤~400 строк, функции ≤~50 строк.
+- Conventional commits (`feat:`/`test:`/`refactor:`/`docs:`), attribution отключён.
+- Один PR из `feat/delta-3-cosign` в main, НЕ self-merge.
+
+## По завершении
+Убедись что build+тесты зелёные и покрытие ≥80%. Обнови `docs/testing/E2E_ANTIGRAVITY_PROMPT.md` секцией про проверку co-подписи и `/verify-chain` витнеса. Открой PR. Кратко отчитайся: что сделано, вывод тестов/покрытия, остаточные риски (напр. «TrustAgentAI + один банк» НЕ закрыт — это осознанный residual из §5.3), что осталось для Delta #4 (anchoring HEAD чекпоинта + heartbeat).

--- a/docs/testing/E2E_ANTIGRAVITY_PROMPT.md
+++ b/docs/testing/E2E_ANTIGRAVITY_PROMPT.md
@@ -48,6 +48,7 @@ curl -sf http://localhost:3002/health   # bank-b-proxy
 curl -sf http://localhost:4001/health   # bank-a-agent
 curl -sf http://localhost:4002/health   # bank-b-agent
 curl -sf http://localhost:5001/health   # bank-b-anchor (merkle notary)
+curl -sf http://localhost:3003/health   # trust-agent-cloud (inline co-sign witness, Delta #3)
 curl -sf http://localhost:3000/         # frontend
 ```
 All must return success. Report any that don't, with `docker compose logs <service> --tail 50`.
@@ -169,6 +170,44 @@ Each proxy links its envelope rows into an append-only hash-chain (`seq` + `prev
    ```
 3. **Tamper-detection (do this on the copied `./bank-b.db.tmp`, NOT the live container DB — do not corrupt the running stack):** edit one row's `raw_payload` in the copy, then run the same verify logic against it, or reason from `/verify-chain` semantics. Expected: mutating any row's content breaks its successor's `prev_hash` link; deleting a row opens a `seq` gap — either makes `verifyChain` return `{"valid": false, "error": ...}`. Report whether the break is detected. (You can confirm this deterministically via the unit tests instead: `cd trust-agent && npm test -- hash-chain` — the tamper and gap cases are covered there.)
 
+## Part 3c — Witness inline co-sign & finality gate (Delta #3)
+
+An independent service, **`trust-agent-cloud`** (port 3003), co-signs each transaction *inline between Phase 2 (Acceptance) and Phase 3 (Execution)*. It is independent of both banks: its own durable Ed25519 key (own `TRUSTAGENT_KEYSTORE_KEK`, separate from the banks' KEKs and from any DB), and its own append-only hash-chain. A transaction that cannot obtain a valid witness co-signature is **not** finalized.
+
+1. Confirm the transaction you drove in Part 2 carries a witness co-signature. Bank-A persists it as a `COSIGN` envelope row alongside INTENT/ACCEPTANCE/EXECUTION:
+   ```bash
+   curl -s "http://localhost:3001/envelopes" | python3 -c "
+   import json,sys
+   rows=[e for e in json.load(sys.stdin) if e.get('trace_id')=='<TRACE_ID>']
+   print(sorted({e['type'] for e in rows}))
+   "
+   ```
+   **PASS criterion:** the set includes `COSIGN` (in addition to `INTENT`, `ACCEPTANCE`, `EXECUTION`). The `COSIGN` row's `raw_payload` is a `CoSignReceipt` whose single signature has `role: "witness"` and `kid: did:workload:trustagent-cloud#key-1`, and whose `intent_hash`/`acceptance_hash` bind this trace's envelopes.
+
+2. The witness's own hash-chain verifies clean, and has exactly one link per co-signed transaction:
+   ```bash
+   curl -s http://localhost:3003/verify-chain | python3 -m json.tool   # expect {"valid": true}
+   docker compose exec trust-agent-cloud sh -c "sqlite3 /data/trust-agent-cloud.db 'SELECT seq, substr(prev_hash,1,12), type, trace_id FROM cosigns ORDER BY seq;'" 2>/dev/null \
+     || (docker cp trust-agent-cloud:/data/trust-agent-cloud.db ./tac.db.tmp && sqlite3 ./tac.db.tmp "SELECT seq, substr(prev_hash,1,12), type, trace_id FROM cosigns ORDER BY seq;")
+   ```
+   Expect a gapless `seq` (0,1,2,…), non-null `prev_hash`, `type=COSIGN`, one row per `trace_id`.
+
+3. Witness key durability (same guarantee as Delta #1, for the witness): the keystore is encrypted at rest and the public key survives a restart.
+   ```bash
+   docker compose exec trust-agent-cloud cat /data/trust-agent-cloud-keystore.json   # JSON {kid, publicKey, iv, ciphertext, tag}
+   docker compose restart trust-agent-cloud                                          # wait until healthy
+   curl -s http://localhost:3003/health                                             # witness_kid unchanged
+   docker compose exec trust-agent-cloud sh -c "strings /data/trust-agent-cloud.db | grep -i privatekey" || true   # must be empty
+   ```
+   **PASS criterion:** keystore is JSON with an encrypted `ciphertext` (no plaintext key), `witness_kid` is identical after restart, and no private-key material appears in the DB.
+
+4. Finality gate (proves the witness is load-bearing, not decorative). With the stack up, take the witness offline, drive a fresh transaction, and confirm it does **not** finalize:
+   ```bash
+   docker compose stop trust-agent-cloud
+   curl -sf -X POST http://localhost:3001/trigger    # or POST /invoke; watch bank-a-proxy logs
+   ```
+   **PASS criterion:** the new transaction is rejected/never completes (Proxy A returns a witness error, code `-32006`, and does **not** produce an EXECUTION for that new trace) — a transaction without a valid co-signature is not valid. Restart the witness afterwards (`docker compose start trust-agent-cloud`, wait healthy). *(Optional deterministic equivalent: `cd trust-agent && npm test -- trust-proxy` covers the gate; `cd trust-agent-cloud && npm test` covers witness verification, chaining, and idempotency.)*
+
 ## Part 4 — Force the on-chain anchor and verify it for real
 
 1. Trigger an immediate anchor of whatever's pending (don't wait for the auto-batch threshold):
@@ -216,5 +255,6 @@ Produce a single markdown report with:
 4. **DB persistence** — row counts/contents from both banks' SQLite, signature re-verification result.
 5. **On-chain anchor** — `tx_hash`, `block_number`, RPC receipt status, Merkle proof verification result, Basescan link.
 6. **Dispute pack** — confirm retrievable and internally consistent.
-7. **Overall verdict** — PASS/FAIL per section, and an explicit note that this run validates Delta #1 (key custody) plus the pre-existing anchor pipeline; it does **not** exercise Deltas #2–7 (hash-chain, inline co-signer, checkpoint/heartbeat, WORM content store, key-transparency, degraded-mode) since those aren't implemented yet — say so plainly rather than implying broader coverage than what ran.
+7. **Witness co-sign (Delta #3)** — `COSIGN` present for the trace, witness `/verify-chain` valid + gapless `cosigns` rows, witness key durable across restart with no leaked private material, and the finality-gate result (transaction rejected while the witness was down).
+8. **Overall verdict** — PASS/FAIL per section, and an explicit note that this run validates Delta #1 (key custody), Delta #2 (hash-chain), Delta #3 (inline co-sign witness + finality gate), plus the pre-existing anchor pipeline; it does **not** exercise Deltas #4–7 (checkpoint/heartbeat anchoring, WORM content store, key-transparency, degraded-mode) since those aren't implemented yet — say so plainly rather than implying broader coverage than what ran. Residual (by design, DISPUTE_HARDENING §5.3): "TrustAgentAI + one bank colluding" is **not** closed by Delta #3.
 8. Any CRITICAL findings called out at the very top, before the section-by-section detail.

--- a/trust-agent-cloud/Dockerfile
+++ b/trust-agent-cloud/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:20-alpine AS builder
+RUN apk add --no-cache python3 make g++
+WORKDIR /workspace
+
+# Build trust-agent first (required for file: dep resolution)
+COPY trust-agent/package.json trust-agent/package-lock.json ./trust-agent/
+RUN cd trust-agent && npm ci --ignore-scripts
+COPY trust-agent/src ./trust-agent/src
+COPY trust-agent/tsconfig.json ./trust-agent/
+RUN cd trust-agent && npm run build
+
+# Build trust-agent-cloud witness service
+COPY trust-agent-cloud/package.json ./trust-agent-cloud/
+# --install-links copies file: deps instead of symlinking (safe for multi-stage builds)
+RUN cd trust-agent-cloud && npm install --install-links
+COPY trust-agent-cloud/src ./trust-agent-cloud/src
+COPY trust-agent-cloud/tsconfig.json ./trust-agent-cloud/
+RUN cd trust-agent-cloud && npm run build
+
+FROM node:20-alpine
+RUN apk add --no-cache sqlite
+WORKDIR /app
+COPY --from=builder /workspace/trust-agent-cloud/dist ./dist
+COPY --from=builder /workspace/trust-agent-cloud/node_modules ./node_modules
+COPY --from=builder /workspace/trust-agent-cloud/package.json ./package.json
+EXPOSE 3003
+CMD ["node", "dist/server.js"]

--- a/trust-agent-cloud/package-lock.json
+++ b/trust-agent-cloud/package-lock.json
@@ -1,0 +1,2960 @@
+{
+  "name": "@trustagentai/trust-agent-cloud",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@trustagentai/trust-agent-cloud",
+      "version": "1.0.0",
+      "dependencies": {
+        "@trustagentai/a2a-core": "file:../trust-agent",
+        "better-sqlite3": "^9.6.0",
+        "cors": "^2.8.6",
+        "express": "^4.22.1"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.11",
+        "@types/cors": "^2.8.19",
+        "@types/express": "^4.17.25",
+        "@types/node": "^20.19.39",
+        "@vitest/coverage-v8": "^4.1.9",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.9"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.3.0.tgz",
+      "integrity": "sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@trustagentai/a2a-core": {
+      "version": "0.5.0-alpha.0",
+      "resolved": "file:../trust-agent",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/ed25519": "^2.1.0",
+        "canonicalize": "^2.0.0",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/trust-agent-cloud/package.json
+++ b/trust-agent-cloud/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@trustagentai/trust-agent-cloud",
+  "version": "1.0.0",
+  "description": "TrustAgentAI Cloud — independent inline co-sign witness (Delta #3). Verifies both proxy signatures, co-signs the transaction, and maintains its own anchored-ready hash-chain.",
+  "type": "module",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@trustagentai/a2a-core": "file:../trust-agent",
+    "better-sqlite3": "^9.6.0",
+    "cors": "^2.8.6",
+    "express": "^4.22.1"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.11",
+    "@types/cors": "^2.8.19",
+    "@types/express": "^4.17.25",
+    "@types/node": "^20.19.39",
+    "@vitest/coverage-v8": "^4.1.9",
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.9"
+  }
+}

--- a/trust-agent-cloud/src/db.ts
+++ b/trust-agent-cloud/src/db.ts
@@ -1,0 +1,126 @@
+/**
+ * TrustAgentAI Cloud — witness co-sign hash-chain (Delta #3)
+ *
+ * The witness owns its own SQLite database, independent of both banks and of
+ * their key-encryption-keys. Every co-signature is persisted as one row in an
+ * append-only chain built on the SHARED hash-chain module (`hash-chain.ts`,
+ * Delta #2): each row carries a monotonic `seq` and a `prev_hash` linking it to
+ * the prior row's content hash. Deleting a row leaves a `seq` gap; editing a
+ * row breaks its successor's `prev_hash`. This makes the witness itself
+ * verifiable — even it cannot silently rewrite history.
+ */
+
+import Database from "better-sqlite3";
+import {
+  GENESIS_PREV_HASH,
+  computeRowHash,
+  verifyChain,
+  type ChainRow,
+  type ChainVerifyResult,
+  type CoSignReceipt,
+} from "@trustagentai/a2a-core";
+
+let db: Database.Database;
+
+/** A co-sign row rehydrated for callers: the receipt plus its chain position. */
+export interface StoredCoSign {
+  receipt: CoSignReceipt;
+  seq: number;
+  prev_hash: string;
+}
+
+export function initDb(path: string): void {
+  db = new Database(path, { timeout: 5000 });
+  db.pragma("journal_mode = WAL");
+  db.pragma("busy_timeout = 5000");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS cosigns (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      trace_id TEXT NOT NULL,
+      raw_payload TEXT NOT NULL,
+      signature TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      seq INTEGER,
+      prev_hash TEXT
+    );
+  `);
+}
+
+/** Map a raw DB row to the shared ChainRow shape (field names already align). */
+function toChainRow(r: any): ChainRow {
+  return {
+    seq: r.seq,
+    prev_hash: r.prev_hash,
+    id: r.id,
+    type: r.type,
+    trace_id: r.trace_id,
+    raw_payload: r.raw_payload,
+    signature: r.signature,
+    created_at: r.created_at,
+  };
+}
+
+/** Deterministic row id for a trace's single co-signature (idempotency key). */
+function rowId(traceId: string): string {
+  return `${traceId}:cosign`;
+}
+
+/**
+ * Append a co-sign receipt to the chain, atomically. Idempotent on `trace_id`:
+ * a second call for the same transaction is a no-op that returns the existing
+ * chain position rather than forking or advancing the chain.
+ */
+export function appendCoSign(
+  traceId: string,
+  receipt: CoSignReceipt
+): { seq: number; prev_hash: string; created: boolean } {
+  const id = rowId(traceId);
+  const now = new Date().toISOString();
+  const payload = JSON.stringify(receipt);
+  const signature = JSON.stringify(receipt.signatures);
+
+  const append = db.transaction(() => {
+    const existing = db.prepare("SELECT seq, prev_hash FROM cosigns WHERE id = ?").get(id) as
+      | { seq: number; prev_hash: string }
+      | undefined;
+    if (existing) {
+      return { seq: existing.seq, prev_hash: existing.prev_hash, created: false };
+    }
+    const head = db.prepare("SELECT * FROM cosigns ORDER BY seq DESC LIMIT 1").get() as any;
+    const seq = head ? head.seq + 1 : 0;
+    const prevHash = head ? computeRowHash(toChainRow(head)) : GENESIS_PREV_HASH;
+    db.prepare(
+      "INSERT INTO cosigns (id, type, trace_id, raw_payload, signature, created_at, seq, prev_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+    ).run(id, "COSIGN", traceId, payload, signature, now, seq, prevHash);
+    return { seq, prev_hash: prevHash, created: true };
+  });
+
+  return append();
+}
+
+/** Look up the co-sign already recorded for a trace, if any. */
+export function getCoSignByTrace(traceId: string): StoredCoSign | null {
+  const row = db.prepare("SELECT * FROM cosigns WHERE id = ?").get(rowId(traceId)) as any;
+  if (!row) return null;
+  return {
+    receipt: JSON.parse(row.raw_payload) as CoSignReceipt,
+    seq: row.seq,
+    prev_hash: row.prev_hash,
+  };
+}
+
+/** All co-sign rows as an ordered chain (seq ascending). */
+export function getCoSignChain(): ChainRow[] {
+  return (db.prepare("SELECT * FROM cosigns ORDER BY seq ASC").all() as any[]).map(toChainRow);
+}
+
+/** Verify the witness chain: no seq gaps, prev_hash links intact. */
+export function verifyCoSignChain(): ChainVerifyResult {
+  return verifyChain(getCoSignChain());
+}
+
+/** Drop all co-sign rows (demo /reset and tests). */
+export function clearCoSigns(): void {
+  db.exec("DELETE FROM cosigns");
+}

--- a/trust-agent-cloud/src/server.ts
+++ b/trust-agent-cloud/src/server.ts
@@ -1,0 +1,95 @@
+/**
+ * TrustAgentAI Cloud — witness HTTP server (Delta #3)
+ *
+ * The independent inline co-signer. Endpoints:
+ *   GET  /health        — liveness + witness key id
+ *   POST /register-key  — a bank registers its proxy public key { kid, publicKeyHex }
+ *   POST /co-sign       — { intent, acceptance } → { cosign_receipt, seq, prev_hash }
+ *   GET  /verify-chain  — verify the witness append-only hash-chain
+ *   POST /reset         — clear the witness chain (demo only)
+ *
+ * The witness holds its OWN durable Ed25519 key (Delta #1) under its OWN KEK,
+ * separate from both banks and from the database.
+ */
+
+import express from "express";
+import cors from "cors";
+import { loadOrCreateKeyPair } from "@trustagentai/a2a-core";
+import type { IntentEnvelope, AcceptanceReceipt } from "@trustagentai/a2a-core";
+import { initDb, verifyCoSignChain, clearCoSigns } from "./db.js";
+import { CoSignService } from "./witness.js";
+
+const PORT = Number(process.env.PORT ?? 3003);
+const DB_PATH = process.env.DB_PATH ?? "/data/trust-agent-cloud.db";
+const KEYSTORE_PATH = process.env.KEYSTORE_PATH ?? "/data/trust-agent-cloud-keystore.json";
+const KEYSTORE_KEK = process.env.KEYSTORE_KEK;
+const WITNESS_KID = "did:workload:trustagent-cloud#key-1";
+
+async function main(): Promise<void> {
+  if (!KEYSTORE_KEK) {
+    throw new Error("KEYSTORE_KEK env var is required to load/create the witness identity keystore");
+  }
+  const witnessKey = await loadOrCreateKeyPair(WITNESS_KID, KEYSTORE_PATH, KEYSTORE_KEK);
+  initDb(DB_PATH);
+  const service = new CoSignService(witnessKey);
+
+  const app = express();
+  app.use(express.json({ limit: "1mb" }));
+  app.use(cors({ origin: "*" }));
+  app.use((req, _res, next) => {
+    console.log(`[trust-agent-cloud] ${req.method} ${req.url}`);
+    next();
+  });
+
+  app.get("/health", (_req, res) =>
+    res.json({ ok: true, witness_kid: witnessKey.kid })
+  );
+
+  app.post("/register-key", (req, res) => {
+    const { kid, publicKeyHex } = req.body as { kid?: string; publicKeyHex?: string };
+    if (!kid || !publicKeyHex) {
+      res.status(400).json({ error: "kid and publicKeyHex are required" });
+      return;
+    }
+    service.registerKey(kid, publicKeyHex);
+    console.log(`[trust-agent-cloud] registered peer key: ${kid}`);
+    res.json({ ok: true });
+  });
+
+  app.post("/co-sign", async (req, res) => {
+    const { intent, acceptance } = req.body as {
+      intent?: IntentEnvelope;
+      acceptance?: AcceptanceReceipt;
+    };
+    if (!intent || !acceptance) {
+      res.status(400).json({ error: "intent and acceptance are required" });
+      return;
+    }
+    try {
+      const { receipt, seq, prev_hash, idempotent } = await service.coSign(intent, acceptance);
+      console.log(
+        `[trust-agent-cloud] CO-SIGNED ${intent.trace_id} — seq=${seq}${idempotent ? " (idempotent)" : ""}`
+      );
+      res.json({ cosign_receipt: receipt, seq, prev_hash, idempotent });
+    } catch (err) {
+      console.warn(`[trust-agent-cloud] REFUSED ${intent.trace_id} — ${err}`);
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  app.get("/verify-chain", (_req, res) => res.json(verifyCoSignChain()));
+
+  app.post("/reset", (_req, res) => {
+    clearCoSigns();
+    res.json({ ok: true });
+  });
+
+  app.listen(PORT, () =>
+    console.log(`TrustAgentAI Cloud witness listening on :${PORT} (kid=${witnessKey.kid})`)
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/trust-agent-cloud/src/witness.test.ts
+++ b/trust-agent-cloud/src/witness.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { tmpdir } from "os";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import {
+  generateKeyPair,
+  loadOrCreateKeyPair,
+  buildIntentEnvelope,
+  buildAcceptanceReceipt,
+  verifyCoSignReceipt,
+} from "@trustagentai/a2a-core";
+import type { KeyPair, IntentEnvelope, AcceptanceReceipt } from "@trustagentai/a2a-core";
+import { initDb, clearCoSigns, getCoSignChain, verifyCoSignChain } from "./db.js";
+import { CoSignService } from "./witness.js";
+
+const KEK = "a".repeat(64); // 32-byte hex, test-only
+
+interface Handshake {
+  intent: IntentEnvelope;
+  acceptance: AcceptanceReceipt;
+  proxyAKey: KeyPair;
+  proxyBKey: KeyPair;
+}
+
+async function makeHandshake(): Promise<Handshake> {
+  const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+  const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+  const { envelope: intent } = await buildIntentEnvelope({
+    initiatorDid: "did:workload:bank-a-agent",
+    vcRef: "vc:test",
+    targetDid: "did:workload:bank-b-proxy",
+    mcpDeploymentId: "did:workload:bank-b-proxy",
+    toolName: "execute_wire_transfer",
+    toolSchemaHash: "deadbeef",
+    mcpSessionId: "sess-1",
+    args: { amount: 100 },
+    proxyKey: proxyAKey,
+  });
+  const acceptance = await buildAcceptanceReceipt({
+    intentEnvelope: intent,
+    policyEvalInput: { decision: "ACCEPTED" },
+    proxyKey: proxyBKey,
+  });
+  return { intent, acceptance, proxyAKey, proxyBKey };
+}
+
+async function serviceWith(h: Handshake): Promise<{ svc: CoSignService; witnessKey: KeyPair }> {
+  const witnessKey = await generateKeyPair("did:workload:trustagent-cloud#key-1");
+  const svc = new CoSignService(witnessKey);
+  svc.registerKey(h.proxyAKey.kid, Buffer.from(h.proxyAKey.publicKey).toString("hex"));
+  svc.registerKey(h.proxyBKey.kid, Buffer.from(h.proxyBKey.publicKey).toString("hex"));
+  return { svc, witnessKey };
+}
+
+beforeEach(() => {
+  initDb(join(tmpdir(), `witness-test-${randomUUID()}.db`));
+  clearCoSigns();
+});
+
+describe("CoSignService.coSign", () => {
+  it("rejects a handshake whose Intent signature is invalid", async () => {
+    const h = await makeHandshake();
+    const { svc } = await serviceWith(h);
+    const tampered: IntentEnvelope = {
+      ...h.intent,
+      payload: { ...h.intent.payload, args_hash: "0".repeat(64) },
+    };
+    await expect(svc.coSign(tampered, h.acceptance)).rejects.toThrow();
+    expect(getCoSignChain()).toHaveLength(0);
+  });
+
+  it("rejects a handshake whose Acceptance signature is invalid", async () => {
+    const h = await makeHandshake();
+    const { svc } = await serviceWith(h);
+    const tampered: AcceptanceReceipt = { ...h.acceptance, policy_eval_hash: "0".repeat(64) };
+    await expect(svc.coSign(h.intent, tampered)).rejects.toThrow();
+    expect(getCoSignChain()).toHaveLength(0);
+  });
+
+  it("co-signs a valid handshake with a witness-verifiable signature", async () => {
+    const h = await makeHandshake();
+    const { svc, witnessKey } = await serviceWith(h);
+
+    const { receipt, seq, prev_hash, idempotent } = await svc.coSign(h.intent, h.acceptance);
+
+    expect(idempotent).toBe(false);
+    expect(seq).toBe(0);
+    expect(prev_hash).toBe("0".repeat(64));
+    await expect(
+      verifyCoSignReceipt(receipt, h.intent, h.acceptance, witnessKey.publicKey)
+    ).resolves.toBeUndefined();
+  });
+
+  it("appends exactly one link to the witness hash-chain and keeps it valid", async () => {
+    const h = await makeHandshake();
+    const { svc } = await serviceWith(h);
+
+    await svc.coSign(h.intent, h.acceptance);
+
+    expect(getCoSignChain()).toHaveLength(1);
+    expect(verifyCoSignChain().valid).toBe(true);
+  });
+
+  it("is idempotent on a duplicate trace_id and does not advance the chain", async () => {
+    const h = await makeHandshake();
+    const { svc } = await serviceWith(h);
+
+    const first = await svc.coSign(h.intent, h.acceptance);
+    const second = await svc.coSign(h.intent, h.acceptance);
+
+    expect(second.idempotent).toBe(true);
+    expect(second.seq).toBe(first.seq);
+    expect(second.prev_hash).toBe(first.prev_hash);
+    expect(getCoSignChain()).toHaveLength(1);
+    expect(verifyCoSignChain().valid).toBe(true);
+  });
+
+  it("chains two distinct transactions in order (seq 0, 1) and stays valid", async () => {
+    const h1 = await makeHandshake();
+    const { svc } = await serviceWith(h1);
+    const r1 = await svc.coSign(h1.intent, h1.acceptance);
+
+    // Second transaction: re-register the (same-kid) keys for its proxies.
+    const h2 = await makeHandshake();
+    svc.registerKey(h2.proxyAKey.kid, Buffer.from(h2.proxyAKey.publicKey).toString("hex"));
+    svc.registerKey(h2.proxyBKey.kid, Buffer.from(h2.proxyBKey.publicKey).toString("hex"));
+    const r2 = await svc.coSign(h2.intent, h2.acceptance);
+
+    expect(r1.seq).toBe(0);
+    expect(r2.seq).toBe(1);
+    expect(getCoSignChain()).toHaveLength(2);
+    expect(verifyCoSignChain().valid).toBe(true);
+  });
+});
+
+describe("witness durable key (Delta #1 reuse)", () => {
+  it("loads the same public key across restarts from an encrypted keystore", async () => {
+    const path = join(tmpdir(), `witness-keystore-${randomUUID()}.json`);
+    const kid = "did:workload:trustagent-cloud#key-1";
+    const first = await loadOrCreateKeyPair(kid, path, KEK);
+    const second = await loadOrCreateKeyPair(kid, path, KEK);
+    expect(Buffer.from(second.publicKey).toString("hex")).toBe(
+      Buffer.from(first.publicKey).toString("hex")
+    );
+  });
+});

--- a/trust-agent-cloud/src/witness.ts
+++ b/trust-agent-cloud/src/witness.ts
@@ -1,0 +1,56 @@
+/**
+ * TrustAgentAI Cloud — CoSignService (Delta #3)
+ *
+ * Orchestrates the inline witness path: verify both proxy signatures against
+ * the witness's OWN key registry, co-sign the transaction, and append the
+ * receipt to the witness hash-chain. The pure crypto lives in the shared
+ * `co-sign.ts` module; SQL/chain storage lives in `db.ts`. This class wires
+ * them and enforces idempotency.
+ */
+
+import {
+  verifyHandshake,
+  buildCoSignReceipt,
+  type IntentEnvelope,
+  type AcceptanceReceipt,
+  type CoSignReceipt,
+  type KeyPair,
+} from "@trustagentai/a2a-core";
+import { appendCoSign, getCoSignByTrace } from "./db.js";
+
+export interface CoSignOutcome {
+  receipt: CoSignReceipt;
+  seq: number;
+  prev_hash: string;
+  idempotent: boolean;
+}
+
+export class CoSignService {
+  /** kid → public key. Populated by each bank registering with the witness. */
+  private readonly keys = new Map<string, Uint8Array>();
+
+  constructor(private readonly witnessKey: KeyPair) {}
+
+  /** Register a proxy's public key so the witness can verify its signatures. */
+  registerKey(kid: string, publicKeyHex: string): void {
+    this.keys.set(kid, Buffer.from(publicKeyHex, "hex"));
+  }
+
+  /**
+   * Co-sign a transaction inline. Idempotent on `trace_id`: a repeat request
+   * returns the existing receipt without re-verifying or advancing the chain.
+   * Throws if the handshake is invalid (bad/unknown signature, unbound intent,
+   * or a non-ACCEPTED decision) — the caller MUST NOT finalize on a throw.
+   */
+  async coSign(intent: IntentEnvelope, acceptance: AcceptanceReceipt): Promise<CoSignOutcome> {
+    const existing = getCoSignByTrace(intent.trace_id);
+    if (existing) {
+      return { ...existing, idempotent: true };
+    }
+
+    await verifyHandshake(intent, acceptance, (kid) => this.keys.get(kid));
+    const receipt = await buildCoSignReceipt(intent, acceptance, this.witnessKey);
+    const { seq, prev_hash } = appendCoSign(intent.trace_id, receipt);
+    return { receipt, seq, prev_hash, idempotent: false };
+  }
+}

--- a/trust-agent-cloud/tsconfig.json
+++ b/trust-agent-cloud/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/trust-agent-cloud/vitest.config.ts
+++ b/trust-agent-cloud/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/db.ts", "src/witness.ts"],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
+  },
+});

--- a/trust-agent/src/co-sign.test.ts
+++ b/trust-agent/src/co-sign.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { generateKeyPair } from "./crypto.js";
+import type { KeyPair } from "./crypto.js";
+import { buildIntentEnvelope, buildAcceptanceReceipt } from "./envelopes.js";
+import type { IntentEnvelope, AcceptanceReceipt } from "./envelopes.js";
+import {
+  verifyHandshake,
+  buildCoSignReceipt,
+  verifyCoSignReceipt,
+} from "./co-sign.js";
+
+interface Handshake {
+  intent: IntentEnvelope;
+  acceptance: AcceptanceReceipt;
+  proxyAKey: KeyPair;
+  proxyBKey: KeyPair;
+}
+
+/** Build a valid Intent + Acceptance handshake signed by two distinct proxies. */
+async function makeHandshake(): Promise<Handshake> {
+  const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+  const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+
+  const { envelope: intent } = await buildIntentEnvelope({
+    initiatorDid: "did:workload:bank-a-agent",
+    vcRef: "vc:test",
+    targetDid: "did:workload:bank-b-proxy",
+    mcpDeploymentId: "did:workload:bank-b-proxy",
+    toolName: "execute_wire_transfer",
+    toolSchemaHash: "deadbeef",
+    mcpSessionId: "sess-1",
+    args: { amount: 100 },
+    proxyKey: proxyAKey,
+  });
+
+  const acceptance = await buildAcceptanceReceipt({
+    intentEnvelope: intent,
+    policyEvalInput: { decision: "ACCEPTED" },
+    proxyKey: proxyBKey,
+  });
+
+  return { intent, acceptance, proxyAKey, proxyBKey };
+}
+
+/** A key registry lookup over the two proxies for a handshake. */
+function lookupFor(h: Handshake): (kid: string) => Uint8Array | undefined {
+  const map = new Map<string, Uint8Array>([
+    [h.proxyAKey.kid, h.proxyAKey.publicKey],
+    [h.proxyBKey.kid, h.proxyBKey.publicKey],
+  ]);
+  return (kid) => map.get(kid);
+}
+
+describe("verifyHandshake", () => {
+  it("accepts a valid Intent + Acceptance signed by known proxies", async () => {
+    const h = await makeHandshake();
+    await expect(verifyHandshake(h.intent, h.acceptance, lookupFor(h))).resolves.toBeUndefined();
+  });
+
+  it("rejects when the Intent signature is invalid (tampered payload)", async () => {
+    const h = await makeHandshake();
+    const tampered: IntentEnvelope = {
+      ...h.intent,
+      payload: { ...h.intent.payload, args_hash: "0".repeat(64) },
+    };
+    await expect(verifyHandshake(tampered, h.acceptance, lookupFor(h))).rejects.toThrow();
+  });
+
+  it("rejects when the Acceptance signature is invalid (tampered field)", async () => {
+    const h = await makeHandshake();
+    const tampered: AcceptanceReceipt = { ...h.acceptance, policy_eval_hash: "0".repeat(64) };
+    await expect(verifyHandshake(h.intent, tampered, lookupFor(h))).rejects.toThrow();
+  });
+
+  it("rejects when a signing key is unknown to the witness", async () => {
+    const h = await makeHandshake();
+    const empty = () => undefined;
+    await expect(verifyHandshake(h.intent, h.acceptance, empty)).rejects.toThrow(/unknown key/i);
+  });
+
+  it("rejects when acceptance does not bind the intent hash", async () => {
+    const h = await makeHandshake();
+    const mismatched: AcceptanceReceipt = { ...h.acceptance, intent_hash: "0".repeat(64) };
+    await expect(verifyHandshake(h.intent, mismatched, lookupFor(h))).rejects.toThrow(/intent/i);
+  });
+
+  it("rejects when the acceptance decision is REJECTED", async () => {
+    const h = await makeHandshake();
+    const denied = await buildAcceptanceReceipt({
+      intentEnvelope: h.intent,
+      policyEvalInput: { decision: "REJECTED" },
+      proxyKey: h.proxyBKey,
+      decision: "REJECTED",
+    });
+    await expect(verifyHandshake(h.intent, denied, lookupFor(h))).rejects.toThrow(/reject/i);
+  });
+
+  it("rejects when trace_id of acceptance and intent diverge", async () => {
+    const h = await makeHandshake();
+    const other = await makeHandshake();
+    await expect(verifyHandshake(h.intent, other.acceptance, lookupFor(h))).rejects.toThrow(/trace/i);
+  });
+});
+
+describe("buildCoSignReceipt / verifyCoSignReceipt", () => {
+  it("produces an Ed25519 co-signature verifiable under the witness key", async () => {
+    const h = await makeHandshake();
+    const witnessKey = await generateKeyPair("did:workload:trustagent-cloud#key-1");
+
+    const receipt = await buildCoSignReceipt(h.intent, h.acceptance, witnessKey);
+
+    expect(receipt.envelope_type).toBe("CoSignReceipt");
+    expect(receipt.trace_id).toBe(h.intent.trace_id);
+    expect(receipt.signatures).toHaveLength(1);
+    expect(receipt.signatures[0].role).toBe("witness");
+    expect(receipt.signatures[0].kid).toBe(witnessKey.kid);
+
+    await expect(
+      verifyCoSignReceipt(receipt, h.intent, h.acceptance, witnessKey.publicKey)
+    ).resolves.toBeUndefined();
+  });
+
+  it("fails verification under a different (impostor) public key", async () => {
+    const h = await makeHandshake();
+    const witnessKey = await generateKeyPair("did:workload:trustagent-cloud#key-1");
+    const impostor = await generateKeyPair("did:workload:impostor#key-1");
+
+    const receipt = await buildCoSignReceipt(h.intent, h.acceptance, witnessKey);
+
+    await expect(
+      verifyCoSignReceipt(receipt, h.intent, h.acceptance, impostor.publicKey)
+    ).rejects.toThrow();
+  });
+
+  it("fails verification when the receipt is re-bound to a different transaction", async () => {
+    const h = await makeHandshake();
+    const other = await makeHandshake();
+    const witnessKey = await generateKeyPair("did:workload:trustagent-cloud#key-1");
+
+    const receipt = await buildCoSignReceipt(h.intent, h.acceptance, witnessKey);
+
+    await expect(
+      verifyCoSignReceipt(receipt, other.intent, other.acceptance, witnessKey.publicKey)
+    ).rejects.toThrow();
+  });
+});

--- a/trust-agent/src/co-sign.ts
+++ b/trust-agent/src/co-sign.ts
@@ -1,0 +1,133 @@
+/**
+ * TrustAgentAI — Inline Witness Co-Signature (Delta #3)
+ *
+ * Pure protocol logic for the independent witness (TrustAgentAI Cloud) that
+ * co-signs a transaction *inline, between handshake Phase 2 (Acceptance) and
+ * Phase 3 (Execution)*. This is the "third independent key" from the threat
+ * model (DISPUTE_HARDENING §3): a transaction that cannot produce a valid
+ * witness co-signature is not final.
+ *
+ * The witness verifies BOTH proxy signatures against keys it holds
+ * independently (banks register their public keys with it), so a collusion of
+ * the two banks alone cannot fabricate a witnessed transaction. Network/SQL
+ * wiring lives in the `trust-agent-cloud/` service; this module is the
+ * testable core.
+ */
+
+import { computeEnvelopeHash, signEnvelope, verifySignature } from "./crypto.js";
+import type { KeyPair, SignatureBlock } from "./crypto.js";
+import type { IntentEnvelope, AcceptanceReceipt } from "./envelopes.js";
+
+/** Resolve a signing key id to its public key, or undefined if unknown. */
+export type PublicKeyLookup = (kid: string) => Uint8Array | undefined;
+
+/**
+ * A witness co-signature receipt. Binds the Intent and Acceptance content
+ * hashes for one `trace_id` and carries a single Ed25519 signature under the
+ * witness key (role `"witness"`). Additive to the existing wire protocol.
+ */
+export interface CoSignReceipt {
+  envelope_type: "CoSignReceipt";
+  spec_version: "0.5";
+  trace_id: string;
+  timestamp: string;
+  intent_hash: string;
+  acceptance_hash: string;
+  signatures: SignatureBlock[];
+}
+
+function requireProxySignature(
+  envelope: IntentEnvelope | AcceptanceReceipt,
+  label: string
+): SignatureBlock {
+  const sig = envelope.signatures.find((s) => s.role === "proxy");
+  if (!sig) throw new Error(`${label} is missing a proxy signature`);
+  return sig;
+}
+
+async function verifyUnderRegistry(
+  envelope: IntentEnvelope | AcceptanceReceipt,
+  sig: SignatureBlock,
+  lookup: PublicKeyLookup
+): Promise<void> {
+  const publicKey = lookup(sig.kid);
+  if (!publicKey) throw new Error(`unknown key: ${sig.kid}`);
+  await verifySignature(envelope as unknown as Record<string, unknown>, sig, publicKey);
+}
+
+/**
+ * Validate an Intent + Acceptance handshake before the witness will co-sign.
+ * Throws if anything is off:
+ *  - the two envelopes disagree on `trace_id`;
+ *  - the acceptance decision is not `ACCEPTED`;
+ *  - the acceptance does not commit the intent's content hash;
+ *  - either proxy signature is missing, from an unknown key, or invalid.
+ */
+export async function verifyHandshake(
+  intent: IntentEnvelope,
+  acceptance: AcceptanceReceipt,
+  lookup: PublicKeyLookup
+): Promise<void> {
+  if (acceptance.trace_id !== intent.trace_id) {
+    throw new Error("trace_id mismatch between intent and acceptance");
+  }
+  if (acceptance.decision !== "ACCEPTED") {
+    throw new Error(`acceptance decision is not ACCEPTED: ${acceptance.decision}`);
+  }
+
+  const intentHash = computeEnvelopeHash(intent as unknown as Record<string, unknown>);
+  if (acceptance.intent_hash !== intentHash) {
+    throw new Error("acceptance does not bind the intent hash");
+  }
+
+  await verifyUnderRegistry(intent, requireProxySignature(intent, "intent"), lookup);
+  await verifyUnderRegistry(acceptance, requireProxySignature(acceptance, "acceptance"), lookup);
+}
+
+/**
+ * Build a witness co-signature receipt binding the intent and acceptance
+ * hashes. Callers MUST run {@link verifyHandshake} first — this function only
+ * signs; it does not re-validate the inputs.
+ */
+export async function buildCoSignReceipt(
+  intent: IntentEnvelope,
+  acceptance: AcceptanceReceipt,
+  witnessKey: KeyPair
+): Promise<CoSignReceipt> {
+  const base: Omit<CoSignReceipt, "signatures"> = {
+    envelope_type: "CoSignReceipt",
+    spec_version: "0.5",
+    trace_id: intent.trace_id,
+    timestamp: new Date().toISOString(),
+    intent_hash: computeEnvelopeHash(intent as unknown as Record<string, unknown>),
+    acceptance_hash: computeEnvelopeHash(acceptance as unknown as Record<string, unknown>),
+  };
+
+  const sig = await signEnvelope(base as Record<string, unknown>, witnessKey, "witness");
+  return { ...base, signatures: [sig] };
+}
+
+/**
+ * Verify a co-sign receipt end-to-end (auditor path): the witness signature is
+ * valid under `witnessPublicKey`, and the receipt still binds the given intent
+ * and acceptance. Throws on any mismatch.
+ */
+export async function verifyCoSignReceipt(
+  receipt: CoSignReceipt,
+  intent: IntentEnvelope,
+  acceptance: AcceptanceReceipt,
+  witnessPublicKey: Uint8Array
+): Promise<void> {
+  const intentHash = computeEnvelopeHash(intent as unknown as Record<string, unknown>);
+  const acceptanceHash = computeEnvelopeHash(acceptance as unknown as Record<string, unknown>);
+  if (receipt.intent_hash !== intentHash) {
+    throw new Error("co-sign receipt does not bind the given intent");
+  }
+  if (receipt.acceptance_hash !== acceptanceHash) {
+    throw new Error("co-sign receipt does not bind the given acceptance");
+  }
+
+  const sig = receipt.signatures.find((s) => s.role === "witness");
+  if (!sig) throw new Error("co-sign receipt is missing a witness signature");
+  await verifySignature(receipt as unknown as Record<string, unknown>, sig, witnessPublicKey);
+}

--- a/trust-agent/src/crypto.ts
+++ b/trust-agent/src/crypto.ts
@@ -22,7 +22,7 @@ export interface KeyPair {
 }
 
 export interface SignatureBlock {
-  role: "proxy" | "agent";
+  role: "proxy" | "agent" | "witness";
   kid: string;
   alg: "EdDSA";
   signed_digest: string;  // hex SHA-256 of the JCS envelope
@@ -140,7 +140,7 @@ export function sha256(input: string | Buffer): string {
 export async function signEnvelope(
   envelope: Record<string, unknown>,
   keyPair: KeyPair,
-  role: "proxy" | "agent" = "proxy",
+  role: "proxy" | "agent" | "witness" = "proxy",
   attestationRef?: string
 ): Promise<SignatureBlock> {
   const signed_digest = computeEnvelopeHash(envelope);

--- a/trust-agent/src/index.ts
+++ b/trust-agent/src/index.ts
@@ -3,6 +3,7 @@
 
 export * from "./crypto.js";
 export * from "./hash-chain.js";
+export * from "./co-sign.js";
 export * from "./envelopes.js";
 export * from "./ledger.js";
 export * from "./nonce-registry.js";

--- a/trust-agent/src/trust-proxy.test.ts
+++ b/trust-agent/src/trust-proxy.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { generateKeyPair } from "./crypto.js";
+import type { KeyPair } from "./crypto.js";
+import { buildAcceptanceReceipt } from "./envelopes.js";
+import type { IntentEnvelope } from "./envelopes.js";
+import { ProxyAGateway } from "./trust-proxy.js";
+import type { McpToolCall } from "./trust-proxy.js";
+
+const WITNESS_URL = "http://witness.test";
+const PROXY_B_URL = "http://proxy-b.test";
+
+function makeCall(): McpToolCall {
+  return {
+    jsonrpc: "2.0",
+    id: "call-1",
+    method: "tools/call",
+    params: {
+      name: "execute_wire_transfer",
+      arguments: { amount: 100 },
+      _initiator_did: "did:workload:bank-a-agent",
+      _vc_ref: "vc:test",
+      _mcp_deployment_id: "did:workload:bank-b-proxy",
+      _tool_schema_hash: "deadbeef",
+      _mcp_session_id: "sess-1",
+    },
+  };
+}
+
+/** JSON fetch Response stub. */
+function jsonResponse(obj: unknown, ok = true): Response {
+  return { ok, status: ok ? 200 : 503, json: async () => obj } as unknown as Response;
+}
+
+/**
+ * Install a fetch mock. `/accept` builds a real acceptance from the posted
+ * intent (signed by proxyB); `/co-sign` is delegated to `coSign`; `/executed`
+ * echoes back nothing so Proxy A keeps its own execution envelope.
+ */
+function installFetch(
+  proxyBKey: KeyPair,
+  coSign: (intent: IntentEnvelope) => Promise<Response>
+): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, opts?: { body?: string }) => {
+      const u = String(url);
+      if (u.endsWith("/accept")) {
+        const body = JSON.parse(opts!.body!) as { intent: IntentEnvelope };
+        const acceptance = await buildAcceptanceReceipt({
+          intentEnvelope: body.intent,
+          policyEvalInput: { decision: "ACCEPTED" },
+          proxyKey: proxyBKey,
+        });
+        return jsonResponse({ acceptance });
+      }
+      if (u.endsWith("/co-sign")) {
+        const body = JSON.parse(opts!.body!) as { intent: IntentEnvelope };
+        return coSign(body.intent);
+      }
+      if (u.endsWith("/executed")) return jsonResponse({});
+      throw new Error(`unexpected fetch to ${u}`);
+    })
+  );
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("ProxyAGateway witness finality gate", () => {
+  it("finalizes with a co-sign receipt attached when the witness co-signs", async () => {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+
+    installFetch(proxyBKey, async (intent) =>
+      jsonResponse({
+        cosign_receipt: {
+          envelope_type: "CoSignReceipt",
+          trace_id: intent.trace_id,
+          signatures: [{ role: "witness", kid: "witness#1" }],
+        },
+        seq: 0,
+        prev_hash: "0".repeat(64),
+      })
+    );
+
+    const gateway = new ProxyAGateway({
+      proxyKey: proxyAKey,
+      proxyBEndpoint: PROXY_B_URL,
+      witnessEndpoint: WITNESS_URL,
+    });
+
+    const executeTool = vi.fn(async () => ({ ok: true }));
+    const result = await gateway.forwardToolCall(makeCall(), executeTool);
+
+    expect(result.error).toBeUndefined();
+    expect(executeTool).toHaveBeenCalledOnce();
+    expect(result.result?._a2a?.cosign_receipt).toBeDefined();
+    expect(result.result?._a2a?.cosign_receipt?.envelope_type).toBe("CoSignReceipt");
+  });
+
+  it("does NOT finalize and does NOT execute the tool when the witness rejects", async () => {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+
+    installFetch(proxyBKey, async () => jsonResponse({ error: "invalid handshake" }, false));
+
+    const gateway = new ProxyAGateway({
+      proxyKey: proxyAKey,
+      proxyBEndpoint: PROXY_B_URL,
+      witnessEndpoint: WITNESS_URL,
+    });
+
+    const executeTool = vi.fn(async () => ({ ok: true }));
+    const result = await gateway.forwardToolCall(makeCall(), executeTool);
+
+    expect(result.result).toBeUndefined();
+    expect(result.error).toBeDefined();
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it("does NOT finalize when the witness is unreachable (fetch throws)", async () => {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+
+    installFetch(proxyBKey, async () => {
+      throw new Error("ECONNREFUSED");
+    });
+
+    const gateway = new ProxyAGateway({
+      proxyKey: proxyAKey,
+      proxyBEndpoint: PROXY_B_URL,
+      witnessEndpoint: WITNESS_URL,
+    });
+
+    const executeTool = vi.fn(async () => ({ ok: true }));
+    const result = await gateway.forwardToolCall(makeCall(), executeTool);
+
+    expect(result.error).toBeDefined();
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it("stays backward compatible: no witness configured → completes without co-sign", async () => {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+
+    installFetch(proxyBKey, async () => {
+      throw new Error("witness should not be called");
+    });
+
+    const gateway = new ProxyAGateway({
+      proxyKey: proxyAKey,
+      proxyBEndpoint: PROXY_B_URL,
+    });
+
+    const executeTool = vi.fn(async () => ({ ok: true }));
+    const result = await gateway.forwardToolCall(makeCall(), executeTool);
+
+    expect(result.error).toBeUndefined();
+    expect(executeTool).toHaveBeenCalledOnce();
+    expect(result.result?._a2a?.cosign_receipt).toBeUndefined();
+  });
+});

--- a/trust-agent/src/trust-proxy.ts
+++ b/trust-agent/src/trust-proxy.ts
@@ -30,6 +30,7 @@ import { verifySignature, signEnvelope } from "./crypto.js";
 import type { KeyPair } from "./crypto.js";
 import { buildIntentEnvelope, buildAcceptanceReceipt, buildExecutionEnvelope } from "./envelopes.js";
 import type { IntentEnvelope, AcceptanceReceipt, ExecutionEnvelope, ContentProvenanceReceipt } from "./envelopes.js";
+import type { CoSignReceipt } from "./co-sign.js";
 import { DAGLedger } from "./ledger.js";
 import { NonceRegistry } from "./nonce-registry.js";
 import { RiskBudgetEngine } from "./risk-budget.js";
@@ -67,6 +68,8 @@ export interface McpToolResult {
       intent_envelope: IntentEnvelope;
       acceptance_receipt: AcceptanceReceipt;
       execution_envelope: ExecutionEnvelope;
+      /** Delta #3: inline witness co-signature. Present when a witness is configured. */
+      cosign_receipt?: CoSignReceipt;
     };
   };
   error?: {
@@ -82,6 +85,7 @@ const ERR_BUDGET_EXCEEDED = -32002;
 const ERR_REPLAY = -32003;
 const ERR_EXPIRED = -32004;
 const ERR_INVALID_SIGNATURE = -32005;
+const ERR_WITNESS_UNAVAILABLE = -32006;
 
 // ─── Proxy A (Initiator Side) ─────────────────────────────────────────────────
 
@@ -90,6 +94,10 @@ export interface ProxyAConfig {
   agentKey?: KeyPair;         // for Dual-Sign
   attestationRef?: string;
   proxyBEndpoint: string;     // URL of Proxy B's /accept endpoint
+  /** Delta #3: independent witness (TrustAgentAI Cloud) /co-sign endpoint. When
+   *  set, a valid inline co-signature is REQUIRED for the transaction to
+   *  finalize; when unset, the gate is skipped (backward compatible). */
+  witnessEndpoint?: string;
   ttlSeconds?: number;
 }
 
@@ -148,6 +156,28 @@ export class ProxyAGateway {
       return this._mcpError(call.id, ERR_UNAUTHORIZED, `Proxy B unreachable: ${err}`);
     }
 
+    // 2.5 Independent witness co-signature (Delta #3). Inline between Phase 2
+    // (Acceptance) and Phase 3 (Execution): the witness verifies both proxy
+    // signatures and co-signs. Without a valid co-signature the transaction is
+    // NOT finalized and the tool is NOT executed — the finality gate.
+    let cosign: CoSignReceipt | undefined;
+    if (this.cfg.witnessEndpoint) {
+      try {
+        const resp = await fetch(`${this.cfg.witnessEndpoint}/co-sign`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ intent: intentEnv, acceptance }),
+        });
+        const body = await resp.json() as { cosign_receipt?: CoSignReceipt; error?: string };
+        if (!resp.ok || !body.cosign_receipt) {
+          return this._mcpError(call.id, ERR_WITNESS_UNAVAILABLE, body.error ?? "Witness declined to co-sign", { traceId: intentEnv.trace_id });
+        }
+        cosign = body.cosign_receipt;
+      } catch (err) {
+        return this._mcpError(call.id, ERR_WITNESS_UNAVAILABLE, `Witness unreachable: ${err}`, { traceId: intentEnv.trace_id });
+      }
+    }
+
     // 3. Execute the actual tool
     let outputData: unknown;
     let status: "COMPLETED" | "FAILED" = "COMPLETED";
@@ -194,7 +224,12 @@ export class ProxyAGateway {
       id: call.id,
       result: {
         content: [{ type: "text", text: JSON.stringify(outputData) }],
-        _a2a: { intent_envelope: intentEnv, acceptance_receipt: acceptance, execution_envelope: finalExecutionEnv },
+        _a2a: {
+          intent_envelope: intentEnv,
+          acceptance_receipt: acceptance,
+          execution_envelope: finalExecutionEnv,
+          ...(cosign ? { cosign_receipt: cosign } : {}),
+        },
       },
     };
   }

--- a/trust-agent/vitest.config.ts
+++ b/trust-agent/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],
-      include: ["src/crypto.ts", "src/hash-chain.ts"],
+      include: ["src/crypto.ts", "src/hash-chain.ts", "src/co-sign.ts"],
       thresholds: {
         lines: 80,
         functions: 80,


### PR DESCRIPTION
## Summary

Implements **Delta #3** from `docs/execution_plan.md` / `DISPUTE_HARDENING.md` §3: an independent inline **co-sign witness** (the "third independent key") that closes *fabrication under two-bank collusion*. It co-signs each transaction **inline between handshake Phase 2 (Acceptance) and Phase 3 (Execution)** and **gates finality** — a transaction that cannot obtain a valid witness co-signature is not executed and not finalized.

## What's new

**Core (`trust-agent/`)**
- `src/co-sign.ts` — pure primitives: `verifyHandshake` (verifies both proxy signatures + intent-hash binding + ACCEPTED decision), `buildCoSignReceipt` (witness-role Ed25519 co-signature), `verifyCoSignReceipt` (auditor path).
- `SignatureBlock.role` widened with additive `"witness"`.
- `ProxyAGateway` — optional `witnessEndpoint`; calls `/co-sign` inline; on failure returns `ERR_WITNESS_UNAVAILABLE (-32006)`, the tool is **not** executed, and the tx is **not** finalized. `cosign_receipt` is attached to `_a2a`. Backward compatible when unset.

**New service (`trust-agent-cloud/`, port 3003)** — independent of both banks:
- own durable Ed25519 key via `loadOrCreateKeyPair` (own `TRUSTAGENT_KEYSTORE_KEK`, separate from bank KEKs and the DB — Delta #1 reuse);
- own append-only hash-chain over `CoSignReceipt`s on the shared `hash-chain.ts` module (Delta #2), idempotent per `trace_id`;
- `POST /co-sign`, `POST /register-key`, `GET /verify-chain`, `GET /health`, `POST /reset`.

**Wiring** — Bank-A passes `witnessEndpoint` + registers its key + persists the `COSIGN` receipt; Bank-B registers its key so acceptance signatures verify; `docker-compose` adds the service (own volume, `depends_on ... healthy`); `.env.example` gets a `TRUSTAGENT_KEYSTORE_KEK` placeholder (real value only in gitignored `.env`).

## Method — strict TDD

RED → GREEN → REFACTOR throughout. Tests written first.

- `trust-agent`: **34 tests pass**. New `co-sign.ts` coverage ~90% stmts / 96% lines (>=80%). New `trust-proxy.test.ts` proves the gate: witness down/rejecting ⇒ tool never runs, tx not finalized; backward-compat path unaffected.
- `trust-agent-cloud`: **7 tests pass**. Covers invalid-signature rejection, verifiable co-signature, exactly-one chain link + `verifyChain` valid, idempotent duplicate `trace_id`, two-tx ordering, witness key durability across restart. `db.ts`/`witness.ts` >=80%.
- End-to-end HTTP smoke against the running witness: health, refuse-before-registration, co-sign, idempotent replay, tampered-intent rejection, `/verify-chain` valid.
- `npm run build` green in `trust-agent`, `trust-agent-cloud`, and both bank proxies.

## Acceptance criteria

- ✅ No valid witness co-signature ⇒ transaction does not finalize (gate).
- ✅ Witness independent: own durable key (own KEK), own anchored-ready hash-chain.
- ✅ Private key bytes never in logs/SQLite (encrypted keystore; verified).
- ✅ Existing happy-path still works, now with `COSIGN` in `_a2a`.

## Residual risks (knowingly accepted)

- **"TrustAgentAI + one bank" collusion is NOT closed** — conscious MVP residual (DISPUTE_HARDENING §5.3).
- Witness is a liveness dependency on the critical path (§5.2) — mutual anchoring + heartbeat is **Delta #4** (checkpoint anchoring of chain HEAD + on-chain heartbeat), the next step.

## Test plan
- [x] `docker compose up --build -d`, run `docs/testing/E2E_ANTIGRAVITY_PROMPT.md` **Part 3c** (witness co-sign, `/verify-chain`, key durability, finality gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)