### PR TITLE
Delta #4 — chain HEAD checkpoint anchoring + on-chain heartbeat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,14 @@ node_modules/
 .pnp
 .pnp.js
 
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.coverage
+htmlcov/
+.venv/
+
 # Testing
 coverage/
 

--- a/Bank-B/merkle-anchor/app/checkpoint_agent.py
+++ b/Bank-B/merkle-anchor/app/checkpoint_agent.py
@@ -1,0 +1,120 @@
+"""
+Delta #4 — CheckpointAgent.
+
+Anchors the per-party chain HEAD checkpoint (not an arbitrary signature batch)
+and publishes the periodic on-chain heartbeat. The notary is duck-typed (any
+object with ``anchor(commitment_hex) -> {tx_hash, block_number}``) so this agent
+is testable without a live chain or web3.
+"""
+
+import sys
+from datetime import datetime, timezone
+
+from domain.checkpoint import build_checkpoint, checkpoint_commitment, is_contiguous
+from domain.heartbeat import Heartbeat, heartbeat_commitment, next_heartbeat
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class CheckpointAgent:
+    def __init__(self, db, notary, party: str = "bank-b") -> None:
+        self._db = db
+        self._notary = notary
+        self._party = party
+
+    def _log(self, message: str) -> None:
+        print(f"[CheckpointAgent - {self._party}] {message}", file=sys.stdout)
+
+    def anchor_checkpoint(self) -> dict:
+        """
+        Read the party's chain, build its HEAD checkpoint, and anchor the
+        commitment on-chain. No-op when the chain is empty or its HEAD is
+        unchanged since the last checkpoint; refuses to anchor a chain with a
+        ``seq`` gap (a deletion must not be silently certified).
+        """
+        rows = self._db.get_chain_rows()
+        checkpoint = build_checkpoint(self._party, rows)
+        if checkpoint is None:
+            self._log("chain is empty — nothing to checkpoint")
+            return {"status": "noop", "message": "chain is empty"}
+
+        if not is_contiguous(rows):
+            self._log("REFUSING to anchor: chain has a seq gap (deletion suspected)")
+            return {"status": "error", "message": "chain has a seq gap; not anchoring"}
+
+        commitment = checkpoint_commitment(checkpoint)
+        last = self._db.get_latest_checkpoint(self._party)
+        if last and last["commitment"] == commitment:
+            self._log(f"HEAD unchanged at seq {checkpoint.head_seq} — no new anchor")
+            return {
+                "status": "noop",
+                "message": "head unchanged",
+                "headSeq": checkpoint.head_seq,
+                "commitment": commitment,
+            }
+
+        self._log(
+            f"anchoring HEAD checkpoint: seq={checkpoint.head_seq} rows={checkpoint.row_count}"
+        )
+        result = self._notary.anchor(commitment)
+        self._db.save_checkpoint(
+            {
+                "party": checkpoint.party,
+                "head_seq": checkpoint.head_seq,
+                "head_prev_hash": checkpoint.head_prev_hash,
+                "row_count": checkpoint.row_count,
+                "commitment": commitment,
+                "tx_hash": result["tx_hash"],
+                "block_number": result["block_number"],
+                "status": "CONFIRMED",
+            }
+        )
+        self._log(f"checkpoint anchored at block {result['block_number']}")
+        return {
+            "status": "success",
+            "party": checkpoint.party,
+            "headSeq": checkpoint.head_seq,
+            "rowCount": checkpoint.row_count,
+            "commitment": commitment,
+            "txHash": result["tx_hash"],
+            "blockNumber": result["block_number"],
+        }
+
+    def publish_heartbeat(self, timestamp: str | None = None) -> dict:
+        """
+        Publish the next heartbeat: a monotonic, self-chaining commitment sent
+        on-chain from the anchor wallet. A gap in the resulting seq/time series
+        is the public signal that the anchor was down (Delta #7 input).
+        """
+        ts = timestamp or _now_iso()
+        last_row = self._db.get_latest_heartbeat()
+        last = (
+            Heartbeat(last_row["seq"], last_row["prev_hash"], last_row["timestamp"])
+            if last_row
+            else None
+        )
+        heartbeat = next_heartbeat(last, ts)
+        commitment = heartbeat_commitment(heartbeat)
+
+        self._log(f"publishing heartbeat seq={heartbeat.seq}")
+        result = self._notary.anchor(commitment)
+        self._db.save_heartbeat(
+            {
+                "seq": heartbeat.seq,
+                "prev_hash": heartbeat.prev_hash,
+                "commitment": commitment,
+                "timestamp": heartbeat.timestamp,
+                "tx_hash": result["tx_hash"],
+                "block_number": result["block_number"],
+                "status": "CONFIRMED",
+            }
+        )
+        return {
+            "status": "success",
+            "seq": heartbeat.seq,
+            "commitment": commitment,
+            "txHash": result["tx_hash"],
+            "blockNumber": result["block_number"],
+        }

--- a/Bank-B/merkle-anchor/domain/checkpoint.py
+++ b/Bank-B/merkle-anchor/domain/checkpoint.py
@@ -1,0 +1,64 @@
+"""
+Delta #4 — per-party chain HEAD checkpoint.
+
+Each party (a bank's `envelopes` chain, the witness's `cosigns` chain) is an
+append-only hash-chain (`seq` + `prev_hash`, Deltas #2/#3). A *checkpoint* pins
+that chain's HEAD position — `(party, head_seq, head_prev_hash, row_count)` — and
+its 32-byte commitment is anchored on Base Sepolia.
+
+Per the defense-in-depth map (DISPUTE_HARDENING §4), checkpoints + heartbeat
+close *"when"* — monotonic public time and ordering that cannot be rewound.
+Tamper-evidence of *content* is the hash-chain's job, so the checkpoint commits
+only to fields already stored in the chain (no row-hash recomputation needed).
+"""
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
+
+
+@dataclass(frozen=True)
+class Checkpoint:
+    party: str
+    head_seq: int
+    head_prev_hash: str
+    row_count: int
+
+
+def _seq(row: Any) -> int:
+    return row["seq"] if isinstance(row, dict) else row.seq
+
+
+def _prev_hash(row: Any) -> str:
+    return row["prev_hash"] if isinstance(row, dict) else row.prev_hash
+
+
+def build_checkpoint(party: str, rows: Sequence[Any]) -> Optional[Checkpoint]:
+    """
+    Build a HEAD checkpoint from chain rows ordered by ``seq`` ascending.
+    Returns ``None`` for an empty chain (nothing to anchor).
+    """
+    if not rows:
+        return None
+    head = rows[-1]
+    return Checkpoint(
+        party=party,
+        head_seq=_seq(head),
+        head_prev_hash=_prev_hash(head),
+        row_count=len(rows),
+    )
+
+
+def checkpoint_commitment(cp: Checkpoint) -> str:
+    """Deterministic 32-byte (hex) SHA-256 commitment anchored on-chain."""
+    payload = f"checkpoint|{cp.party}|{cp.head_seq}|{cp.head_prev_hash}|{cp.row_count}"
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def is_contiguous(rows: Sequence[Any]) -> bool:
+    """
+    True when ``seq`` values form a gapless zero-based run (0, 1, 2, …). A gap
+    means a row was deleted between checkpoints — the anchor must not certify a
+    broken chain. An empty chain is vacuously contiguous.
+    """
+    return all(_seq(row) == i for i, row in enumerate(rows))

--- a/Bank-B/merkle-anchor/domain/heartbeat.py
+++ b/Bank-B/merkle-anchor/domain/heartbeat.py
@@ -1,0 +1,61 @@
+"""
+Delta #4 — signed on-chain heartbeat.
+
+The anchor publishes a periodic heartbeat: a 0-ETH self-transaction whose data
+field carries a monotonic, self-chaining commitment ``(seq, prev_hash,
+timestamp)``. Because every heartbeat is sent from the anchor's known wallet
+address, its authenticity is the transaction signature itself; because they
+chain (each ``prev_hash`` = the previous heartbeat's commitment) and increment
+``seq``, a missing beat leaves a provable gap.
+
+A heartbeat gap is the public signal that the witness / anchor was unavailable —
+the input Delta #7 (degraded-mode discipline) reconciles against.
+"""
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional, Sequence
+
+GENESIS_HEARTBEAT_HASH = "0" * 64
+
+
+@dataclass(frozen=True)
+class Heartbeat:
+    seq: int
+    prev_hash: str
+    timestamp: str  # ISO-8601 (UTC)
+
+
+def heartbeat_commitment(hb: Heartbeat) -> str:
+    """Deterministic 32-byte (hex) SHA-256 commitment anchored on-chain."""
+    payload = f"heartbeat|{hb.seq}|{hb.prev_hash}|{hb.timestamp}"
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def next_heartbeat(last: Optional[Heartbeat], timestamp: str) -> Heartbeat:
+    """Build the next heartbeat, chaining it to ``last`` (or genesis if first)."""
+    if last is None:
+        return Heartbeat(seq=0, prev_hash=GENESIS_HEARTBEAT_HASH, timestamp=timestamp)
+    return Heartbeat(seq=last.seq + 1, prev_hash=heartbeat_commitment(last), timestamp=timestamp)
+
+
+def _parse(ts: str) -> datetime:
+    # datetime.fromisoformat on Python 3.10 does not accept a trailing "Z".
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def find_heartbeat_gaps(
+    heartbeats: Sequence[Heartbeat], max_interval_seconds: float
+) -> list[dict]:
+    """
+    Return gaps where consecutive heartbeats are further apart in time than
+    ``max_interval_seconds``. Each gap is ``{"after_seq", "gap_seconds"}``.
+    Heartbeats are assumed ordered by ``seq`` ascending.
+    """
+    gaps: list[dict] = []
+    for prev, curr in zip(heartbeats, heartbeats[1:]):
+        delta = (_parse(curr.timestamp) - _parse(prev.timestamp)).total_seconds()
+        if delta > max_interval_seconds:
+            gaps.append({"after_seq": prev.seq, "gap_seconds": delta})
+    return gaps

--- a/Bank-B/merkle-anchor/infra/db.py
+++ b/Bank-B/merkle-anchor/infra/db.py
@@ -37,6 +37,32 @@ class SQLiteRepository:
                 proof_path  TEXT NOT NULL,
                 PRIMARY KEY (batch_id, leaf_index)
             );
+
+            -- Delta #4: per-party chain HEAD checkpoints
+            CREATE TABLE IF NOT EXISTS checkpoints (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                party          TEXT NOT NULL,
+                head_seq       INTEGER NOT NULL,
+                head_prev_hash TEXT NOT NULL,
+                row_count      INTEGER NOT NULL,
+                commitment     TEXT NOT NULL,
+                tx_hash        TEXT,
+                block_number   INTEGER,
+                status         TEXT NOT NULL DEFAULT 'PENDING',
+                created_at     TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            -- Delta #4: monotonic on-chain heartbeat chain
+            CREATE TABLE IF NOT EXISTS heartbeats (
+                seq          INTEGER PRIMARY KEY,
+                prev_hash    TEXT NOT NULL,
+                commitment   TEXT NOT NULL,
+                timestamp    TEXT NOT NULL,
+                tx_hash      TEXT,
+                block_number INTEGER,
+                status       TEXT NOT NULL DEFAULT 'PENDING',
+                created_at   TEXT NOT NULL DEFAULT (datetime('now'))
+            );
         """)
         self._conn.commit()
 
@@ -113,6 +139,77 @@ class SQLiteRepository:
                ORDER BY al.leaf_index ASC""",
             (batch_id,),
         ).fetchall()
+        return [dict(r) for r in rows]
+
+    # ── Delta #4: chain HEAD checkpoints + heartbeats ──────────────────────
+
+    def get_chain_rows(self) -> list[dict]:
+        """
+        The party's append-only hash-chain rows (seq + prev_hash), ordered by
+        ``seq``. Reads the `envelopes` table the TS proxy links (Delta #2).
+        """
+        rows = self._conn.execute(
+            """SELECT id, type, trace_id, seq, prev_hash, created_at
+               FROM envelopes
+               WHERE seq IS NOT NULL
+               ORDER BY seq ASC"""
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def _now_iso(self) -> str:
+        import datetime
+        return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    def save_checkpoint(self, record: dict) -> None:
+        self._conn.execute(
+            """INSERT INTO checkpoints
+               (party, head_seq, head_prev_hash, row_count, commitment, tx_hash, block_number, status, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                record["party"], record["head_seq"], record["head_prev_hash"],
+                record["row_count"], record["commitment"], record.get("tx_hash"),
+                record.get("block_number"), record.get("status", "PENDING"), self._now_iso(),
+            ),
+        )
+        self._conn.commit()
+
+    def get_latest_checkpoint(self, party: str) -> Optional[dict]:
+        row = self._conn.execute(
+            "SELECT * FROM checkpoints WHERE party = ? ORDER BY head_seq DESC, id DESC LIMIT 1",
+            (party,),
+        ).fetchone()
+        return dict(row) if row else None
+
+    def get_checkpoints(self, party: Optional[str] = None) -> list[dict]:
+        if party is None:
+            rows = self._conn.execute("SELECT * FROM checkpoints ORDER BY id ASC").fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM checkpoints WHERE party = ? ORDER BY id ASC", (party,)
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def save_heartbeat(self, record: dict) -> None:
+        self._conn.execute(
+            """INSERT OR REPLACE INTO heartbeats
+               (seq, prev_hash, commitment, timestamp, tx_hash, block_number, status, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                record["seq"], record["prev_hash"], record["commitment"], record["timestamp"],
+                record.get("tx_hash"), record.get("block_number"),
+                record.get("status", "PENDING"), self._now_iso(),
+            ),
+        )
+        self._conn.commit()
+
+    def get_latest_heartbeat(self) -> Optional[dict]:
+        row = self._conn.execute(
+            "SELECT * FROM heartbeats ORDER BY seq DESC LIMIT 1"
+        ).fetchone()
+        return dict(row) if row else None
+
+    def get_heartbeats(self) -> list[dict]:
+        rows = self._conn.execute("SELECT * FROM heartbeats ORDER BY seq ASC").fetchall()
         return [dict(r) for r in rows]
 
     def close(self) -> None:

--- a/Bank-B/merkle-anchor/main.py
+++ b/Bank-B/merkle-anchor/main.py
@@ -6,6 +6,7 @@ from flask import Flask, jsonify
 from flask_cors import CORS
 
 from app.accounting_agent import AccountingAgent
+from app.checkpoint_agent import CheckpointAgent
 from infra.db import SQLiteRepository
 from infra.notary import BlockchainNotary
 
@@ -61,5 +62,107 @@ def trigger_anchor():
         _anchor_lock.release()
 
 
+def _open_notary_and_db():
+    """Shared setup for the checkpoint/heartbeat on-chain endpoints.
+
+    Returns (db, notary, None) on success, or (None, None, (response, code)) on
+    an environment/connection error. Caller owns closing `db` and releasing the
+    anchor lock.
+    """
+    rpc_url = os.getenv("RPC_URL")
+    private_key = os.getenv("PRIVATE_KEY")
+    if not rpc_url or not private_key:
+        return None, None, (jsonify({"error": "RPC_URL and PRIVATE_KEY must be set"}), 500)
+    db = SQLiteRepository(os.getenv("DB_PATH", "/data/bank-b.db"))
+    notary = BlockchainNotary(rpc_url=rpc_url, private_key=private_key)
+    if not notary.is_connected:
+        db.close()
+        return None, None, (jsonify({"error": f"Cannot connect to RPC at {rpc_url}"}), 500)
+    return db, notary, None
+
+
+def _party() -> str:
+    return os.getenv("CHECKPOINT_PARTY", "bank-b")
+
+
+@app.route('/checkpoint', methods=['POST'])
+def trigger_checkpoint():
+    """Anchor the party's chain HEAD checkpoint (Delta #4)."""
+    if not _anchor_lock.acquire(blocking=False):
+        return jsonify({"status": "noop", "message": "Anchor already in progress"}), 200
+    db, notary, err = _open_notary_and_db()
+    if err:
+        _anchor_lock.release()
+        return err
+    try:
+        return jsonify(CheckpointAgent(db=db, notary=notary, party=_party()).anchor_checkpoint())
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+    finally:
+        db.close()
+        _anchor_lock.release()
+
+
+@app.route('/heartbeat', methods=['POST'])
+def trigger_heartbeat():
+    """Publish the next signed on-chain heartbeat (Delta #4)."""
+    if not _anchor_lock.acquire(blocking=False):
+        return jsonify({"status": "noop", "message": "Anchor already in progress"}), 200
+    db, notary, err = _open_notary_and_db()
+    if err:
+        _anchor_lock.release()
+        return err
+    try:
+        return jsonify(CheckpointAgent(db=db, notary=notary, party=_party()).publish_heartbeat())
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+    finally:
+        db.close()
+        _anchor_lock.release()
+
+
+@app.route('/checkpoints', methods=['GET'])
+def list_checkpoints():
+    db = SQLiteRepository(os.getenv("DB_PATH", "/data/bank-b.db"))
+    try:
+        return jsonify(db.get_checkpoints())
+    finally:
+        db.close()
+
+
+@app.route('/heartbeats', methods=['GET'])
+def list_heartbeats():
+    db = SQLiteRepository(os.getenv("DB_PATH", "/data/bank-b.db"))
+    try:
+        return jsonify(db.get_heartbeats())
+    finally:
+        db.close()
+
+
+def _heartbeat_loop() -> None:
+    """Periodically publish an on-chain heartbeat. Opt-in via HEARTBEAT_ENABLED
+    so dev/CI does not continuously spend burner-wallet gas."""
+    import time
+    interval = int(os.getenv("HEARTBEAT_INTERVAL_SECONDS", "60"))
+    while True:
+        time.sleep(interval)
+        if not _anchor_lock.acquire(blocking=False):
+            continue
+        db, notary, err = _open_notary_and_db()
+        if err:
+            _anchor_lock.release()
+            continue
+        try:
+            CheckpointAgent(db=db, notary=notary, party=_party()).publish_heartbeat()
+        except Exception as e:  # pragma: no cover - background best-effort
+            print(f"[heartbeat] failed: {e}", file=sys.stderr)
+        finally:
+            db.close()
+            _anchor_lock.release()
+
+
 if __name__ == "__main__":
+    if os.getenv("HEARTBEAT_ENABLED", "").lower() == "true":
+        threading.Thread(target=_heartbeat_loop, daemon=True).start()
+        print("[heartbeat] periodic publisher enabled", file=sys.stdout)
     app.run(host="0.0.0.0", port=5001)

--- a/Bank-B/merkle-anchor/pyproject.toml
+++ b/Bank-B/merkle-anchor/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]
+addopts = "--cov=domain.checkpoint --cov=domain.heartbeat --cov=app.checkpoint_agent --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.report]
+exclude_lines = ["pragma: no cover", "if __name__ == .__main__.:"]

--- a/Bank-B/merkle-anchor/requirements-dev.txt
+++ b/Bank-B/merkle-anchor/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest>=8.0.0
+pytest-cov>=5.0.0

--- a/Bank-B/merkle-anchor/tests/test_checkpoint.py
+++ b/Bank-B/merkle-anchor/tests/test_checkpoint.py
@@ -1,0 +1,59 @@
+"""Delta #4 — per-party chain HEAD checkpoint (pure logic)."""
+
+from domain.checkpoint import (
+    Checkpoint,
+    build_checkpoint,
+    checkpoint_commitment,
+    is_contiguous,
+)
+
+GENESIS = "0" * 64
+
+
+def _row(seq: int, prev_hash: str) -> dict:
+    return {"seq": seq, "prev_hash": prev_hash}
+
+
+def test_build_checkpoint_returns_none_for_empty_chain():
+    assert build_checkpoint("bank-b", []) is None
+
+
+def test_build_checkpoint_pins_head_seq_prev_hash_and_count():
+    rows = [_row(0, GENESIS), _row(1, "aa" * 32), _row(2, "bb" * 32)]
+    cp = build_checkpoint("bank-b", rows)
+    assert cp == Checkpoint(party="bank-b", head_seq=2, head_prev_hash="bb" * 32, row_count=3)
+
+
+def test_commitment_is_32_byte_hex_and_deterministic():
+    cp = Checkpoint(party="bank-b", head_seq=2, head_prev_hash="bb" * 32, row_count=3)
+    c1 = checkpoint_commitment(cp)
+    c2 = checkpoint_commitment(cp)
+    assert c1 == c2
+    assert len(c1) == 64
+    int(c1, 16)  # valid hex
+
+
+def test_commitment_changes_when_head_advances():
+    a = Checkpoint("bank-b", 2, "bb" * 32, 3)
+    b = Checkpoint("bank-b", 3, "cc" * 32, 4)
+    assert checkpoint_commitment(a) != checkpoint_commitment(b)
+
+
+def test_commitment_is_party_scoped():
+    a = Checkpoint("bank-b", 2, "bb" * 32, 3)
+    b = Checkpoint("witness", 2, "bb" * 32, 3)
+    assert checkpoint_commitment(a) != checkpoint_commitment(b)
+
+
+def test_is_contiguous_true_for_gapless_zero_based_sequence():
+    rows = [_row(0, GENESIS), _row(1, "aa" * 32), _row(2, "bb" * 32)]
+    assert is_contiguous(rows) is True
+
+
+def test_is_contiguous_false_on_seq_gap():
+    rows = [_row(0, GENESIS), _row(2, "bb" * 32)]  # missing seq 1
+    assert is_contiguous(rows) is False
+
+
+def test_is_contiguous_true_for_empty():
+    assert is_contiguous([]) is True

--- a/Bank-B/merkle-anchor/tests/test_checkpoint_agent.py
+++ b/Bank-B/merkle-anchor/tests/test_checkpoint_agent.py
@@ -1,0 +1,156 @@
+"""Delta #4 — CheckpointAgent integration (mocked notary, temp SQLite)."""
+
+import sqlite3
+
+import pytest
+
+from app.checkpoint_agent import CheckpointAgent
+from domain.heartbeat import GENESIS_HEARTBEAT_HASH, heartbeat_commitment, Heartbeat
+from infra.db import SQLiteRepository
+
+
+class FakeNotary:
+    """Duck-typed stand-in for BlockchainNotary — records calls, no chain."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self._block = 1000
+
+    def anchor(self, commitment_hex: str) -> dict:
+        self.calls.append(commitment_hex)
+        self._block += 1
+        return {"tx_hash": "0x" + commitment_hex[:8], "block_number": self._block}
+
+
+@pytest.fixture
+def repo(tmp_path):
+    path = str(tmp_path / "bank-b.db")
+    # The `envelopes` table is created by the TS proxy in production; create it
+    # here so the anchor can read the chain.
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """CREATE TABLE envelopes (
+             id TEXT PRIMARY KEY, type TEXT, trace_id TEXT, raw_payload TEXT,
+             signature TEXT, created_at TEXT, seq INTEGER, prev_hash TEXT)"""
+    )
+    conn.commit()
+    conn.close()
+    r = SQLiteRepository(path)
+    yield r
+    r.close()
+
+
+def _seed_chain(repo: SQLiteRepository, count: int, start: int = 0) -> None:
+    conn = repo._conn
+    for i in range(start, start + count):
+        prev = "0" * 64 if i == 0 else f"{i - 1:02x}" * 32
+        conn.execute(
+            "INSERT INTO envelopes (id, type, trace_id, raw_payload, signature, created_at, seq, prev_hash)"
+            " VALUES (?,?,?,?,?,?,?,?)",
+            (f"id{i}", "INTENT", f"t{i}", "{}", f"sig{i}", f"2026-07-06T00:00:{i:02d}Z", i, prev),
+        )
+    conn.commit()
+
+
+# ── checkpoint ────────────────────────────────────────────────────────────────
+
+def test_empty_chain_is_a_noop(repo):
+    notary = FakeNotary()
+    result = CheckpointAgent(repo, notary, party="bank-b").anchor_checkpoint()
+    assert result["status"] == "noop"
+    assert notary.calls == []
+
+
+def test_anchors_head_checkpoint_and_persists_it(repo):
+    _seed_chain(repo, 3)
+    notary = FakeNotary()
+    agent = CheckpointAgent(repo, notary, party="bank-b")
+
+    result = agent.anchor_checkpoint()
+
+    assert result["status"] == "success"
+    assert result["headSeq"] == 2
+    assert result["rowCount"] == 3
+    assert len(notary.calls) == 1
+    assert notary.calls[0] == result["commitment"]
+
+    saved = repo.get_latest_checkpoint("bank-b")
+    assert saved["head_seq"] == 2
+    assert saved["row_count"] == 3
+    assert saved["status"] == "CONFIRMED"
+    assert saved["tx_hash"] == result["txHash"]
+
+
+def test_reanchoring_an_unchanged_head_is_a_noop(repo):
+    _seed_chain(repo, 3)
+    notary = FakeNotary()
+    agent = CheckpointAgent(repo, notary, party="bank-b")
+
+    agent.anchor_checkpoint()
+    second = agent.anchor_checkpoint()
+
+    assert second["status"] == "noop"
+    assert len(notary.calls) == 1  # not called again
+
+
+def test_advancing_the_chain_anchors_a_new_checkpoint(repo):
+    _seed_chain(repo, 3)
+    notary = FakeNotary()
+    agent = CheckpointAgent(repo, notary, party="bank-b")
+    agent.anchor_checkpoint()
+
+    _seed_chain(repo, 2, start=3)  # now seq 0..4
+    result = agent.anchor_checkpoint()
+
+    assert result["status"] == "success"
+    assert result["headSeq"] == 4
+    assert result["rowCount"] == 5
+    assert len(notary.calls) == 2
+    assert len(repo.get_checkpoints("bank-b")) == 2
+
+
+def test_refuses_to_anchor_a_chain_with_a_seq_gap(repo):
+    _seed_chain(repo, 2)  # seq 0,1
+    repo._conn.execute(
+        "INSERT INTO envelopes (id, type, trace_id, raw_payload, signature, created_at, seq, prev_hash)"
+        " VALUES (?,?,?,?,?,?,?,?)",
+        ("id3", "INTENT", "t3", "{}", "sig3", "2026-07-06T00:00:03Z", 3, "aa" * 32),  # gap: seq 2 missing
+    )
+    repo._conn.commit()
+    notary = FakeNotary()
+
+    result = CheckpointAgent(repo, notary, party="bank-b").anchor_checkpoint()
+
+    assert result["status"] == "error"
+    assert notary.calls == []
+
+
+# ── heartbeat ─────────────────────────────────────────────────────────────────
+
+def test_first_heartbeat_is_seq_zero_from_genesis(repo):
+    notary = FakeNotary()
+    agent = CheckpointAgent(repo, notary, party="bank-b")
+
+    result = agent.publish_heartbeat(timestamp="2026-07-06T00:00:00Z")
+
+    assert result["status"] == "success"
+    assert result["seq"] == 0
+    assert len(notary.calls) == 1
+    saved = repo.get_latest_heartbeat()
+    assert saved["seq"] == 0
+    assert saved["prev_hash"] == GENESIS_HEARTBEAT_HASH
+
+
+def test_heartbeats_chain_and_increment(repo):
+    notary = FakeNotary()
+    agent = CheckpointAgent(repo, notary, party="bank-b")
+
+    r0 = agent.publish_heartbeat(timestamp="2026-07-06T00:00:00Z")
+    r1 = agent.publish_heartbeat(timestamp="2026-07-06T00:00:30Z")
+
+    assert r1["seq"] == 1
+    hb0 = Heartbeat(0, GENESIS_HEARTBEAT_HASH, "2026-07-06T00:00:00Z")
+    saved = repo.get_heartbeats()
+    assert [h["seq"] for h in saved] == [0, 1]
+    assert saved[1]["prev_hash"] == heartbeat_commitment(hb0)
+    assert r0["commitment"] != r1["commitment"]

--- a/Bank-B/merkle-anchor/tests/test_heartbeat.py
+++ b/Bank-B/merkle-anchor/tests/test_heartbeat.py
@@ -1,0 +1,63 @@
+"""Delta #4 — signed on-chain heartbeat chain (pure logic)."""
+
+from domain.heartbeat import (
+    GENESIS_HEARTBEAT_HASH,
+    Heartbeat,
+    find_heartbeat_gaps,
+    heartbeat_commitment,
+    next_heartbeat,
+)
+
+
+def test_first_heartbeat_starts_at_seq_zero_from_genesis():
+    hb = next_heartbeat(None, "2026-07-06T00:00:00Z")
+    assert hb.seq == 0
+    assert hb.prev_hash == GENESIS_HEARTBEAT_HASH
+    assert hb.timestamp == "2026-07-06T00:00:00Z"
+
+
+def test_next_heartbeat_increments_seq_and_links_prev_hash():
+    hb0 = next_heartbeat(None, "2026-07-06T00:00:00Z")
+    hb1 = next_heartbeat(hb0, "2026-07-06T00:00:30Z")
+    assert hb1.seq == 1
+    assert hb1.prev_hash == heartbeat_commitment(hb0)
+
+
+def test_commitment_is_32_byte_hex_and_deterministic():
+    hb = Heartbeat(seq=0, prev_hash=GENESIS_HEARTBEAT_HASH, timestamp="2026-07-06T00:00:00Z")
+    c1 = heartbeat_commitment(hb)
+    c2 = heartbeat_commitment(hb)
+    assert c1 == c2
+    assert len(c1) == 64
+    int(c1, 16)
+
+
+def test_commitment_changes_with_timestamp():
+    a = Heartbeat(0, GENESIS_HEARTBEAT_HASH, "2026-07-06T00:00:00Z")
+    b = Heartbeat(0, GENESIS_HEARTBEAT_HASH, "2026-07-06T00:00:30Z")
+    assert heartbeat_commitment(a) != heartbeat_commitment(b)
+
+
+def test_no_gaps_when_heartbeats_are_within_interval():
+    hbs = [
+        Heartbeat(0, GENESIS_HEARTBEAT_HASH, "2026-07-06T00:00:00Z"),
+        Heartbeat(1, "x", "2026-07-06T00:00:30Z"),
+        Heartbeat(2, "y", "2026-07-06T00:01:00Z"),
+    ]
+    assert find_heartbeat_gaps(hbs, max_interval_seconds=60) == []
+
+
+def test_detects_gap_when_interval_exceeded():
+    hbs = [
+        Heartbeat(0, GENESIS_HEARTBEAT_HASH, "2026-07-06T00:00:00Z"),
+        Heartbeat(1, "x", "2026-07-06T00:05:00Z"),  # 300s gap
+    ]
+    gaps = find_heartbeat_gaps(hbs, max_interval_seconds=60)
+    assert len(gaps) == 1
+    assert gaps[0]["after_seq"] == 0
+    assert gaps[0]["gap_seconds"] == 300.0
+
+
+def test_no_gaps_for_single_or_empty_series():
+    assert find_heartbeat_gaps([], 60) == []
+    assert find_heartbeat_gaps([Heartbeat(0, GENESIS_HEARTBEAT_HASH, "2026-07-06T00:00:00Z")], 60) == []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,12 @@ services:
       RPC_URL: "${RPC_URL}"
       PRIVATE_KEY: "${PRIVATE_KEY}"
       DB_PATH: "/data/bank-b.db"
+      # Delta #4: chain HEAD checkpoints + on-chain heartbeat. The heartbeat
+      # publisher is opt-in (it continuously spends burner-wallet gas); the
+      # /checkpoint and /heartbeat endpoints work regardless.
+      CHECKPOINT_PARTY: "bank-b"
+      HEARTBEAT_ENABLED: "${HEARTBEAT_ENABLED:-false}"
+      HEARTBEAT_INTERVAL_SECONDS: "${HEARTBEAT_INTERVAL_SECONDS:-60}"
       PYTHONUNBUFFERED: "1"
     volumes:
       - bank-b-data:/data

--- a/docs/testing/E2E_ANTIGRAVITY_PROMPT.md
+++ b/docs/testing/E2E_ANTIGRAVITY_PROMPT.md
@@ -231,6 +231,35 @@ An independent service, **`trust-agent-cloud`** (port 3003), co-signs each trans
    ```
    Confirm the response indicates the proof is valid for your `trace_id`'s leaf.
 
+## Part 4b — Chain HEAD checkpoint & heartbeat (Delta #4)
+
+The anchor now also anchors each party's **chain HEAD checkpoint** (`{party, head_seq, head_prev_hash, row_count}` → 32-byte commitment) and can publish a **monotonic on-chain heartbeat**. Per the design these close *"when"* (public ordering/time), not tampering — so the commitment binds only chain-position fields.
+
+1. Anchor the Bank-B chain HEAD checkpoint (after Part 2 drove at least one transaction, so the chain is non-empty):
+   ```bash
+   curl -sf -X POST http://localhost:5001/checkpoint | python3 -m json.tool
+   ```
+   Expect `status: "success"`, a `headSeq`/`rowCount` matching Bank-B's `/verify-chain` head, a `commitment`, and a real `txHash`/`blockNumber`. Verify the tx on Base Sepolia independently:
+   ```bash
+   curl -s -X POST "$RPC_URL" -H 'content-type: application/json' \
+     -d '{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionReceipt","params":["<TX_HASH>"]}' | python3 -m json.tool
+   ```
+   `status` must be `"0x1"`, and the tx `input`/`data` must equal `0x<commitment>`.
+
+2. Idempotence: re-POST `/checkpoint` with **no new envelopes** → `status: "noop"` (`head unchanged`), no new on-chain tx. Then drive another transaction (Part 2) and re-POST → a **new** checkpoint at a higher `headSeq`.
+   ```bash
+   curl -s http://localhost:5001/checkpoints | python3 -m json.tool   # gapless, head_seq increasing, status CONFIRMED
+   ```
+
+3. Heartbeat — publish two beats and confirm they chain and increment:
+   ```bash
+   curl -sf -X POST http://localhost:5001/heartbeat | python3 -m json.tool   # seq 0
+   curl -sf -X POST http://localhost:5001/heartbeat | python3 -m json.tool   # seq 1
+   curl -s http://localhost:5001/heartbeats | python3 -m json.tool
+   ```
+   **PASS criterion:** `seq` is a gapless 0,1,…; each beat's `prev_hash` equals the previous beat's `commitment` (genesis `0×64` for seq 0); each carries a confirmed `tx_hash`. (The periodic background publisher is opt-in via `HEARTBEAT_ENABLED=true` — it continuously spends gas, so leave it off unless specifically exercising it; the endpoints above are sufficient.)
+   *(Optional deterministic equivalent, no gas: `cd Bank-B/merkle-anchor && python3 -m pytest` — checkpoint HEAD/idempotence/gap-refusal and heartbeat chaining/gap-detection are covered against a mocked notary.)*
+
 ## Part 5 — Dispute pack sanity check
 
 ```bash
@@ -256,5 +285,6 @@ Produce a single markdown report with:
 5. **On-chain anchor** — `tx_hash`, `block_number`, RPC receipt status, Merkle proof verification result, Basescan link.
 6. **Dispute pack** — confirm retrievable and internally consistent.
 7. **Witness co-sign (Delta #3)** — `COSIGN` present for the trace, witness `/verify-chain` valid + gapless `cosigns` rows, witness key durable across restart with no leaked private material, and the finality-gate result (transaction rejected while the witness was down).
-8. **Overall verdict** — PASS/FAIL per section, and an explicit note that this run validates Delta #1 (key custody), Delta #2 (hash-chain), Delta #3 (inline co-sign witness + finality gate), plus the pre-existing anchor pipeline; it does **not** exercise Deltas #4–7 (checkpoint/heartbeat anchoring, WORM content store, key-transparency, degraded-mode) since those aren't implemented yet — say so plainly rather than implying broader coverage than what ran. Residual (by design, DISPUTE_HARDENING §5.3): "TrustAgentAI + one bank colluding" is **not** closed by Delta #3.
+8. **Checkpoint & heartbeat (Delta #4)** — HEAD checkpoint anchored (tx on-chain, data = commitment), idempotent no-op on unchanged head, gapless `checkpoints`; heartbeats chain + increment with confirmed txs.
+9. **Overall verdict** — PASS/FAIL per section, and an explicit note that this run validates Delta #1 (key custody), Delta #2 (hash-chain), Delta #3 (inline co-sign witness + finality gate), Delta #4 (chain HEAD checkpoint + on-chain heartbeat), plus the pre-existing anchor pipeline; it does **not** exercise Deltas #5–7 (WORM content store, key-transparency, degraded-mode) since those aren't implemented yet — say so plainly rather than implying broader coverage than what ran. Residual (by design, DISPUTE_HARDENING §5.3): "TrustAgentAI + one bank colluding" is **not** closed. Delta #4 narrows §5.2 (a heartbeat gap now makes anchor/witness downtime publicly provable) but full degraded-mode discipline (reconciliation window + value cap) is Delta #7.
 8. Any CRITICAL findings called out at the very top, before the section-by-section detail.


### PR DESCRIPTION
> **Stacked on #20 (Delta #3).** Base is `feat/delta-3-cosign` so this diff is Delta #4 only. Merge #20 first, then this.

## Summary

Implements **Delta #4** from `docs/execution_plan.md` / `DISPUTE_HARDENING.md` §6.4: anchor each party's **chain HEAD checkpoint** (not an arbitrary signature batch) and publish a **monotonic on-chain heartbeat**. Per the defense-in-depth map (§4), these close **"when"** — public, monotonic ordering/time — while tamper-evidence stays the hash-chain's job. So a checkpoint commits only to chain-position fields already stored in SQLite (no cross-language row-hash reimplementation).

## What's new (`Bank-B/merkle-anchor/`)

**Pure domain (100% covered)**
- `domain/checkpoint.py` — `build_checkpoint` pins `(party, head_seq, head_prev_hash, row_count)`; `checkpoint_commitment` → 32-byte SHA-256; `is_contiguous` refuses to anchor a chain with a `seq` gap (a deletion must not be silently certified).
- `domain/heartbeat.py` — `next_heartbeat` builds a monotonic, self-chaining commitment (`prev_hash` = previous beat's commitment); `find_heartbeat_gaps` surfaces downtime (the Delta #7 degraded-mode input).

**Service**
- `app/checkpoint_agent.py` — `anchor_checkpoint` (idempotent no-op on unchanged HEAD; refuses gapped chains) and `publish_heartbeat`. Notary is **duck-typed** → testable with no live chain / no web3.
- `infra/db.py` — `checkpoints` + `heartbeats` tables; `get_chain_rows` reads the Delta #2 `envelopes` chain.
- `main.py` — `POST /checkpoint`, `POST /heartbeat`, `GET /checkpoints`, `GET /heartbeats`; an **opt-in** periodic heartbeat publisher (`HEARTBEAT_ENABLED`, default off — it continuously spends gas).

**Infra** — `docker-compose` adds `CHECKPOINT_PARTY` + opt-in heartbeat env to `bank-b-anchor`; `.gitignore` ignores Python caches; `pytest`+coverage harness stood up (`pyproject.toml`, `requirements-dev.txt`).

## Method — TDD (pytest)

Pure modules strict RED→GREEN. Integration (agent + real SQLite + **mocked notary**, per the agreed scope) written before the agent.
- **22 tests pass**, **98.9% coverage** on the three new modules (`checkpoint.py` 100%, `heartbeat.py` 100%, `checkpoint_agent.py` 98%).
- On-chain sends are **wired but mocked in tests**; real Base Sepolia checkpoint/heartbeat txs are exercised via the E2E prompt **Part 4b** (needs burner gas).

## Acceptance criteria
- ✅ Anchors the per-party chain **HEAD checkpoint**, not an arbitrary batch; idempotent when the head is unchanged.
- ✅ Refuses to anchor a chain with a `seq` gap.
- ✅ Periodic signed on-chain heartbeat; gaps are detectable (`find_heartbeat_gaps`).

## Residual / scope
- Checkpoints the **Bank-B `envelopes` chain** (the DB the anchor mounts). The logic is `party`-parameterized; checkpointing the **witness `cosigns` chain** needs its volume mounted into the anchor — small follow-up.
- Delta #4 narrows §5.2 (anchor/witness downtime is now publicly provable via heartbeat gaps); full degraded-mode discipline (reconciliation window + value cap) is **Delta #7**.

## Test plan
- [ ] `cd Bank-B/merkle-anchor && python3 -m pytest` (green, ≥80%).
- [ ] `docker compose up --build -d`, then E2E prompt **Part 4b** (live checkpoint + heartbeat on Base Sepolia).

🤖 Generated with [Claude Code](https://claude.com/claude-code)