### PR TITLE
feat: WORM content store + envelope-encryption (Delta #5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,21 @@ BANK_B_KEYSTORE_KEK=replace_with_64_hex_chars
 # Delta #3 — the TrustAgentAI Cloud witness holds its OWN durable key under its
 # OWN KEK, separate from both banks and from the database.
 TRUSTAGENT_KEYSTORE_KEK=replace_with_64_hex_chars
+
+# Delta #5 — WORM content store envelope-encryption. Per-tx DEKs are wrapped
+# once per holder KEK below. These are content-encryption keys, NOT identity
+# keystore KEKs (unrelated to the *_KEYSTORE_KEK values above).
+#
+# Bank-A builds the record (it's the plaintext origin) and therefore needs
+# every holder's KEK to wrap that holder's copy of the DEK — same
+# shared-secret-KEK model used everywhere else in this repo (see
+# docs/execution_plan.md §5 for the residual note on this).
+BANK_A_CONTENT_KEK=replace_with_64_hex_chars
+CLIENT_CONTENT_KEK=replace_with_64_hex_chars
+TRUSTAGENT_CONTENT_KEK=replace_with_64_hex_chars
+
+# Regulator escrow KEK (Decision #11 / DISPUTE_HARDENING §5.4): unwraps the
+# escrow entry on every WORM record. MUST NOT be configured on the
+# trust-agent-cloud (witness) service — escrow is deliberately NOT held by
+# TrustAgentAI. Holder = the regulator (or a threshold quorum), never us.
+REGULATOR_ESCROW_KEK=replace_with_64_hex_chars

--- a/Bank-A/proxy/src/server.ts
+++ b/Bank-A/proxy/src/server.ts
@@ -5,9 +5,12 @@ import {
   loadOrCreateKeyPair,
   ProxyAGateway,
   buildContentProvenanceReceipt,
+  buildWormRecord,
+  canonicalBytes,
   sha256Json,
   computeEnvelopeHash,
   type McpToolCall,
+  type Holder,
 } from "@trustagentai/a2a-core";
 import {
   initDb,
@@ -20,6 +23,7 @@ import {
   getThoughts,
   verifyEnvelopeChain,
 } from "./db.js";
+import { initWormDb, putContentBlob } from "./worm-db.js";
 import { SseBus } from "./sse.js";
 import { registerWithProxyB, registerWithWitness } from "./key-exchange.js";
 
@@ -31,8 +35,24 @@ const KEYSTORE_PATH = process.env.KEYSTORE_PATH ?? "/data/bank-a-keystore.json";
 const KEYSTORE_KEK = process.env.KEYSTORE_KEK;
 const INITIATOR_DID = "did:workload:bank-a-agent";
 const PROXY_KID = "did:workload:bank-a-proxy#key-1";
+const WORM_DB_PATH = process.env.WORM_DB_PATH ?? DB_PATH;
 
 let triggered = false;
+
+/**
+ * Delta #5: content-encryption KEKs, one per WORM holder. Distinct from the
+ * identity KEYSTORE_KEK above — these wrap per-transaction DEKs, not signing
+ * keys. Optional: if any is missing the WORM store is disabled for this run
+ * (existing happy-path keeps working; see docs/execution_plan.md §5).
+ */
+function parseContentKek(envVar: string): Buffer | undefined {
+  const value = process.env[envVar];
+  if (!value) return undefined;
+  if (!/^[0-9a-fA-F]{64}$/.test(value)) {
+    throw new Error(`${envVar} must be 64 hex characters (32 bytes)`);
+  }
+  return Buffer.from(value, "hex");
+}
 
 async function main(): Promise<void> {
   if (!KEYSTORE_KEK) {
@@ -52,7 +72,52 @@ async function main(): Promise<void> {
   }
 
   initDb(DB_PATH);
+  initWormDb(WORM_DB_PATH);
   const sseBus = new SseBus();
+
+  // Delta #5: WORM content store holders. Bank-A is the plaintext origin, so
+  // it builds the encrypted record and wraps the DEK for every cross-held
+  // party plus a regulator escrow entry that TrustAgentAI cannot unwrap
+  // (DISPUTE_HARDENING §5.4).
+  const bankAKek = parseContentKek("BANK_A_CONTENT_KEK");
+  const clientKek = parseContentKek("CLIENT_CONTENT_KEK");
+  const witnessContentKek = parseContentKek("TRUSTAGENT_CONTENT_KEK");
+  const regulatorKek = parseContentKek("REGULATOR_ESCROW_KEK");
+  const wormHolders: Holder[] | undefined =
+    bankAKek && clientKek && witnessContentKek
+      ? [
+          { id: "bank-a", kek: bankAKek },
+          { id: "client", kek: clientKek },
+          { id: "witness", kek: witnessContentKek },
+        ]
+      : undefined;
+  const wormEscrow: Holder | undefined = regulatorKek ? { id: "regulator", kek: regulatorKek } : undefined;
+  if (!wormHolders || !wormEscrow) {
+    console.warn("[worm] content-KEK env vars not fully configured — WORM content store disabled");
+  }
+
+  async function storeWormContent(value: unknown): Promise<void> {
+    if (!wormHolders || !wormEscrow) return;
+    try {
+      const plaintext = canonicalBytes(value);
+      const record = buildWormRecord(plaintext, wormHolders, wormEscrow);
+      putContentBlob(record.contentHash, record);
+      if (TRUSTAGENT_URL) {
+        await fetch(`${TRUSTAGENT_URL}/blob/${record.contentHash}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            ciphertext: record.ciphertext,
+            iv: record.iv,
+            tag: record.tag,
+            wrappedDeks: record.wrappedDeks,
+          }),
+        });
+      }
+    } catch (e) {
+      console.warn("[worm] failed to store/cross-push content blob", e);
+    }
+  }
 
   const proxyA = new ProxyAGateway({
     proxyKey,
@@ -274,6 +339,15 @@ async function main(): Promise<void> {
         ts,
       });
       sseBus.broadcast("envelope", { type: "EXECUTION", traceId: execution.trace_id, ts });
+
+      // Delta #5: persist args/outputData as encrypted, content-addressed WORM
+      // blobs. Today only sha256Json(args)/sha256Json(outputData) survive in
+      // the envelopes (args_hash/output_hash) — this makes the plaintext they
+      // commit to recoverable by a holder, without ever storing it in the
+      // clear ourselves.
+      const outputData: unknown = JSON.parse(mcpResult.result!.content[0].text);
+      await storeWormContent(args);
+      await storeWormContent(outputData);
 
       const contentHash = sha256Json(mcpResult.result!.content);
       const contentSize = Buffer.byteLength(JSON.stringify(mcpResult.result!.content));

--- a/Bank-A/proxy/src/worm-db.ts
+++ b/Bank-A/proxy/src/worm-db.ts
@@ -1,0 +1,94 @@
+/**
+ * Bank-A proxy — local WORM content store (Delta #5)
+ *
+ * Bank-A is the origin of the plaintext (it has `args`/`outputData` directly
+ * from the `/invoke` call), so it is the party that builds the encrypted,
+ * content-addressed record (see `buildWormRecord` in `@trustagentai/a2a-core`)
+ * and is naturally one of the cross-held copies. This module just persists
+ * that already-encrypted record locally — never plaintext, never a bare DEK —
+ * with the same write-once invariant as the witness's blob store: a repeat
+ * put for the same content hash is idempotent if byte-identical, rejected if
+ * it differs.
+ */
+
+import Database from "better-sqlite3";
+
+let db: Database.Database;
+
+interface WrappedDek {
+  iv: string;
+  ciphertext: string;
+  tag: string;
+}
+
+export interface StoredBlob {
+  contentHash: string;
+  ciphertext: string;
+  iv: string;
+  tag: string;
+  wrappedDeks: Record<string, WrappedDek>;
+}
+
+export function initWormDb(path: string): void {
+  db = new Database(path, { timeout: 5000 });
+  db.pragma("journal_mode = WAL");
+  db.pragma("busy_timeout = 5000");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS content_blobs (
+      content_hash TEXT PRIMARY KEY,
+      ciphertext TEXT NOT NULL,
+      iv TEXT NOT NULL,
+      tag TEXT NOT NULL,
+      wrapped_deks TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+  `);
+}
+
+function toStoredBlob(r: any): StoredBlob {
+  return {
+    contentHash: r.content_hash,
+    ciphertext: r.ciphertext,
+    iv: r.iv,
+    tag: r.tag,
+    wrappedDeks: JSON.parse(r.wrapped_deks),
+  };
+}
+
+function serializeContent(b: Pick<StoredBlob, "ciphertext" | "iv" | "tag" | "wrappedDeks">): string {
+  return JSON.stringify({ ciphertext: b.ciphertext, iv: b.iv, tag: b.tag, wrappedDeks: b.wrappedDeks });
+}
+
+export type BlobInput = Pick<StoredBlob, "ciphertext" | "iv" | "tag" | "wrappedDeks">;
+
+export interface PutBlobResult {
+  blob: StoredBlob;
+  created: boolean;
+}
+
+/** Write-once put, identical invariant to the witness's blob-db.ts. */
+export function putContentBlob(contentHash: string, blob: BlobInput): PutBlobResult {
+  const existingRow = db.prepare("SELECT * FROM content_blobs WHERE content_hash = ?").get(contentHash) as any;
+  if (existingRow) {
+    const existing = toStoredBlob(existingRow);
+    if (serializeContent(existing) === serializeContent(blob)) {
+      return { blob: existing, created: false };
+    }
+    throw new Error(`WORM violation: blob ${contentHash} already stored with different content`);
+  }
+
+  db.prepare(
+    "INSERT INTO content_blobs (content_hash, ciphertext, iv, tag, wrapped_deks, created_at) VALUES (?, ?, ?, ?, ?, ?)"
+  ).run(contentHash, blob.ciphertext, blob.iv, blob.tag, JSON.stringify(blob.wrappedDeks), new Date().toISOString());
+
+  return { blob: { contentHash, ...blob }, created: true };
+}
+
+export function getContentBlob(contentHash: string): StoredBlob | undefined {
+  const row = db.prepare("SELECT * FROM content_blobs WHERE content_hash = ?").get(contentHash) as any;
+  return row ? toStoredBlob(row) : undefined;
+}
+
+export function clearContentBlobs(): void {
+  db.exec("DELETE FROM content_blobs");
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,14 @@ services:
       DB_PATH: "/data/bank-a.db"
       KEYSTORE_PATH: "/data/bank-a-keystore.json"
       KEYSTORE_KEK: "${BANK_A_KEYSTORE_KEK}"
+      # Delta #5: WORM content store — per-holder envelope-encryption KEKs.
+      # All four must be set for Bank-A to actually store/cross-push content;
+      # if any is missing the proxy logs a warning and skips WORM storage
+      # (existing envelope/hash-chain/witness behavior is unaffected).
+      BANK_A_CONTENT_KEK: "${BANK_A_CONTENT_KEK}"
+      CLIENT_CONTENT_KEK: "${CLIENT_CONTENT_KEK}"
+      TRUSTAGENT_CONTENT_KEK: "${TRUSTAGENT_CONTENT_KEK}"
+      REGULATOR_ESCROW_KEK: "${REGULATOR_ESCROW_KEK}"
     volumes:
       - bank-a-data:/data
     depends_on:

--- a/docs/execution_plan.md
+++ b/docs/execution_plan.md
@@ -44,10 +44,10 @@ Monorepo, three runtime languages:
 export interface KeyPair { privateKey: Uint8Array; publicKey: Uint8Array; kid: string; }
 export async function generateKeyPair(kid: string): Promise<KeyPair>
 ```
-Keys are generated fresh at boot in `server.ts` and never persisted — this is the target of Delta #1.
+~~Keys are generated fresh at boot~~ — **resolved in Delta #1**: both proxies and the witness now load a durable Ed25519 identity via `loadOrCreateKeyPair(kid, keystorePath, kek)` from an encrypted (AES-256-GCM) keystore, KEK from env (`KEYSTORE_PATH`/`KEYSTORE_KEK`), fail-fast when absent.
 
-### ⚠ Test infrastructure gap
-The proxies have **no test runner** (`package.json` scripts are only `build`/`start`). Delta #1 must **stand up a test harness first**. Recommended: **Vitest** (native ESM + TS, works with the existing tsconfig). Add `"test"` and `"test:coverage"` scripts. This is a prerequisite, not optional — the working agreement below mandates TDD.
+### Test infrastructure (stood up)
+**Vitest** in `trust-agent/` and `trust-agent-cloud/` (`npm test`, `npm run test:coverage`, 80% threshold in `vitest.config.ts` — add new modules to `coverage.include`). **pytest** in `Bank-B/merkle-anchor/` (`python3 -m pytest`, `pyproject.toml`, `requirements-dev.txt`). The bank proxies still delegate their tested logic to `@trustagentai/a2a-core`; keep new pure logic there.
 
 ## 4. Working agreement (non-negotiable)
 
@@ -61,7 +61,7 @@ The proxies have **no test runner** (`package.json` scripts are only `build`/`st
 
 ## 5. Delta backlog (execute in order — each unblocks the next)
 
-### Delta #1 — Durable, custodied keys  ← START HERE
+### Delta #1 — Durable, custodied keys  ✅ DONE (PR #18, merged to main)
 **Objective:** proxies load a persistent Ed25519 identity from an **encrypted keystore** instead of minting a new key every boot. KEK comes from a secret separate from the DB.
 
 - **Files:** [trust-agent/src/crypto.ts](../trust-agent/src/crypto.ts) (add keystore fns), [Bank-A/proxy/src/server.ts:34](../Bank-A/proxy/src/server.ts#L34), [Bank-B/proxy/src/server.ts:84](../Bank-B/proxy/src/server.ts#L84).
@@ -78,19 +78,36 @@ The proxies have **no test runner** (`package.json` scripts are only `build`/`st
 - **Tests (write first):** same-key-on-reload; tamper-ciphertext → auth failure; wrong-KEK → failure; new keystore created when absent; env-missing → fail-fast.
 - **Residual note:** software keys are a knowingly-accepted compromise (see DISPUTE_HARDENING §5.1). The KEK-isolation requirement is what makes it meaningful — do not shortcut it.
 
-### Delta #2 — Append-only hash-chain
+### Delta #2 — Append-only hash-chain  ✅ DONE (PR #19, merged to main)
 Add `seq` (monotonic per party) + `prev_hash` to the `envelopes` table; on write, link each row to the previous head; expose a chain-verify function (no gaps, links intact).
-→ [Bank-A/proxy/src/db.ts](../Bank-A/proxy/src/db.ts), [Bank-B/proxy/src/db.ts](../Bank-B/proxy/src/db.ts). Migration must handle existing rows.
+→ Shared module [trust-agent/src/hash-chain.ts](../trust-agent/src/hash-chain.ts) (`GENESIS_PREV_HASH`, `computeRowHash`, `verifyChain`, `ChainRow`); [Bank-A/proxy/src/db.ts](../Bank-A/proxy/src/db.ts), [Bank-B/proxy/src/db.ts](../Bank-B/proxy/src/db.ts) link rows + backfill. `GET /verify-chain` on both proxies.
 
-### Delta #3 — TrustAgentAI inline co-sign service (new)
+### Delta #3 — TrustAgentAI inline co-sign service (new)  ✅ DONE (PR #20, open — branch `feat/delta-3-cosign`)
 New service co-signing between handshake Phase 2 and Phase 3; maintains its own hash-chain; gates finality. Wire into `ProxyAGateway`.
+→ Service [trust-agent-cloud/](../trust-agent-cloud/) (own durable key, own `cosigns` chain, `POST /co-sign`, `POST /register-key`, `GET /verify-chain`); pure logic [trust-agent/src/co-sign.ts](../trust-agent/src/co-sign.ts); `ProxyAGateway.witnessEndpoint` gates finality (`_a2a.cosign_receipt`, `ERR_WITNESS_UNAVAILABLE`). **Reusable as a cross-holder for Delta #5.**
 
-### Delta #4 — Checkpoint anchoring + heartbeat
+### Delta #4 — Checkpoint anchoring + heartbeat  ✅ DONE (PR #21, open — stacked on #20, branch `feat/delta-4-anchoring`)
 Anchor the per-party chain **HEAD checkpoint** (not an arbitrary signature batch); add a periodic signed on-chain heartbeat publisher for degraded-mode detection.
-→ [Bank-B/merkle-anchor/app/accounting_agent.py](../Bank-B/merkle-anchor/app/accounting_agent.py), [infra/notary.py](../Bank-B/merkle-anchor/infra/notary.py), [domain/merkle.py](../Bank-B/merkle-anchor/domain/merkle.py).
+→ [domain/checkpoint.py](../Bank-B/merkle-anchor/domain/checkpoint.py), [domain/heartbeat.py](../Bank-B/merkle-anchor/domain/heartbeat.py), [app/checkpoint_agent.py](../Bank-B/merkle-anchor/app/checkpoint_agent.py); endpoints `POST /checkpoint`, `POST /heartbeat`, `GET /checkpoints|/heartbeats`; opt-in periodic publisher (`HEARTBEAT_ENABLED`). Checkpoints Bank-B's chain today; `party`-parameterized so the witness `cosigns` chain is a small follow-up.
 
-### Delta #5 — WORM content store + envelope-encryption
-Persist plaintext args/output as encrypted, content-addressed blobs (per-tx DEK); cross-push to TrustAgentAI + client; bind content hash into the chain. Today these are *"hashed, NOT stored"* ([envelopes.ts:23](../trust-agent/src/envelopes.ts#L23)).
+### Delta #5 — WORM content store + envelope-encryption  ← NEXT (branch `feat/delta-5-worm`, stacked on #4)
+**Objective:** stop discarding the plaintext. Today `args`/`outputData` are *"hashed, NOT stored"* — only `args_hash`/`output_hash` live in envelopes ([envelopes.ts](../trust-agent/src/envelopes.ts): `payload.args_hash = sha256Json(args)`, `result.output_hash = sha256Json(outputData)`; "will be hashed, NOT stored" comments). Persist them as **encrypted, content-addressed WORM blobs**, cross-held so *what* happened survives a two-bank collusion, and stays confidential (DISPUTE §4/§5, Decisions #5 & #11).
+
+- **Settled design (do not re-open):**
+  - **Content-addressed WORM:** blob id = `sha256(plaintext)` = the commitment already in the envelope (**DoD #1**). Write-once: same content → idempotent; different content under the same id → rejected.
+  - **Per-tx DEK:** random 256-bit key per transaction, AES-256-GCM over the content (reuse the AES-GCM pattern in [crypto.ts](../trust-agent/src/crypto.ts)).
+  - **Envelope-encryption:** wrap the DEK under each holder's KEK. Holders = TrustAgentAI (witness), client, banks.
+  - **Regulator escrow:** a separate escrow-wrapped DEK the **regulator** can unwrap and TrustAgentAI **cannot** — escrow key is NOT held by the witness (DISPUTE §5.4). Model the regulator as an independent holder/KEK.
+  - **Cross-push:** after local WORM write, push the encrypted blob to ≥1 other holder (witness `trust-agent-cloud` + a "client" store).
+  - **Bind into chain:** the content commitment is already in the envelope; ensure the WORM blob reconciles with it and `verifyChain` stays valid. Encryption/storage is **additive** — do not break envelope wire shape or `signed_digest`.
+- **Build:** pure crypto/content-addressing modules in [trust-agent/src](../trust-agent/src) (DEK gen, encrypt/decrypt, wrap/unwrap per holder, escrow-wrap, id==commitment check), exported from `@trustagentai/a2a-core`; a WORM blob store + `PUT/GET /blob/:contentHash` on the witness (ciphertext + wrapped-DEKs only, never plaintext/keys) and locally in the proxies; wire into Bank-A `/invoke`; holder/escrow KEKs as env placeholders in `.env.example` (real in gitignored `.env`).
+- **Acceptance criteria:**
+  - Plaintext stored as an encrypted content-addressed blob; `sha256(plaintext)` == the envelope's `args_hash`/`output_hash` (**DoD #1**).
+  - Per-tx DEK; envelope-encryption; regulator escrow present and **NOT** held by TrustAgentAI (§5.4).
+  - Content cross-held (TrustAgentAI + client, minimum).
+  - Logs/SQLite contain only ciphertext + wrapped DEKs — never plaintext content or bare keys/DEK.
+  - Existing happy-path works; builds green in `trust-agent/`, `trust-agent-cloud/`, both proxies; coverage ≥80% on new modules.
+- **Tests (write first):** encrypt↔decrypt round-trip; tamper ciphertext / wrong DEK → GCM auth failure; content-address == commitment (DoD #1); wrap/unwrap under holder KEK round-trip, wrong KEK fails; escrow unwraps for the regulator but not for the witness; WORM write-once (idempotent same-content, reject different-content); cross-hold on ≥2 holders; `verifyChain` still valid.
 
 ### Delta #6 — Key-transparency registry
 Replace mutable `register-peer-key` with an append-only, anchored registry: validity windows, revocation-as-append, rotations endorsed by the prior key.
@@ -112,4 +129,12 @@ An external auditor can run all five checks and any tamper/deletion/fabrication/
 ## 7. Handoff status
 
 - Design: **accepted** (this doc + DISPUTE_HARDENING.md).
-- Code: **not started.** Next action = Delta #1 on branch `feat/delta-1-durable-keys`.
+- Progress (as of 2026-07-06):
+  - **Delta #1** durable keys — ✅ merged (PR #18).
+  - **Delta #2** hash-chain — ✅ merged (PR #19).
+  - **Delta #3** inline co-sign witness — ✅ PR #20 open (`feat/delta-3-cosign`), not yet merged.
+  - **Delta #4** checkpoint + heartbeat — ✅ PR #21 open, **stacked on #20** (`feat/delta-4-anchoring`).
+  - **Delta #5** WORM + envelope-encryption — ⏳ **NEXT.** Branch `feat/delta-5-worm` already created off #4 and pushed.
+- **Branch stack:** `main` → #20 `feat/delta-3-cosign` → #21 `feat/delta-4-anchoring` → `feat/delta-5-worm`. Open Delta #5's PR with **base `feat/delta-4-anchoring`** so the diff is Delta #5 only. Merge order: #20, then #21, then #5's PR. Do not self-merge.
+- **Verification harness:** `docs/testing/E2E_ANTIGRAVITY_PROMPT.md` exercises the full stack (Parts cover Deltas #1–4); extend it per delta.
+- **Next action:** implement **Delta #5** (§5 above) on `feat/delta-5-worm`, strict TDD.

--- a/docs/testing/E2E_ANTIGRAVITY_PROMPT.md
+++ b/docs/testing/E2E_ANTIGRAVITY_PROMPT.md
@@ -208,6 +208,69 @@ An independent service, **`trust-agent-cloud`** (port 3003), co-signs each trans
    ```
    **PASS criterion:** the new transaction is rejected/never completes (Proxy A returns a witness error, code `-32006`, and does **not** produce an EXECUTION for that new trace) — a transaction without a valid co-signature is not valid. Restart the witness afterwards (`docker compose start trust-agent-cloud`, wait healthy). *(Optional deterministic equivalent: `cd trust-agent && npm test -- trust-proxy` covers the gate; `cd trust-agent-cloud && npm test` covers witness verification, chaining, and idempotency.)*
 
+## Part 3d — WORM content store & envelope-encryption (Delta #5)
+
+`args`/`outputData` are no longer discarded — Bank-A persists them as encrypted, content-addressed WORM blobs (per-tx DEK, AES-256-GCM), envelope-encrypted for each holder (`bank-a`, `client`, `witness`) plus a separate regulator escrow entry. Requires `BANK_A_CONTENT_KEK`, `CLIENT_CONTENT_KEK`, `TRUSTAGENT_CONTENT_KEK`, `REGULATOR_ESCROW_KEK` in `.env` — WORM storage silently no-ops (existing flow keeps working) if any is missing.
+
+1. Confirm WORM is active (no "disabled" warning):
+   ```bash
+   docker compose logs bank-a-proxy | grep -i worm
+   ```
+   If it shows "content-KEK env vars not fully configured", set the 4 vars above in `.env`, `docker compose up -d --build bank-a-proxy`, and re-drive Part 2 before continuing.
+
+2. **DoD #1 — content address equals the envelope's committed hash.** Pull the trace's `args_hash`/`output_hash` and Bank-A's local blob table:
+   ```bash
+   curl -s "http://localhost:3001/envelopes" | python3 -c "
+   import json,sys
+   rows=[e for e in json.load(sys.stdin) if e.get('trace_id')=='<TRACE_ID>']
+   for r in rows:
+       if r['type'] in ('INTENT','EXECUTION'):
+           p=json.loads(r['raw_payload'])
+           print(r['type'], p.get('payload',{}).get('args_hash') or p.get('result',{}).get('output_hash'))
+   "
+   docker compose exec bank-a-proxy sh -c "sqlite3 /data/bank-a.db 'SELECT content_hash FROM content_blobs;'" 2>/dev/null \
+     || (docker cp bank-a-proxy:/data/bank-a.db ./bank-a.db.tmp && sqlite3 ./bank-a.db.tmp "SELECT content_hash FROM content_blobs;")
+   ```
+   **PASS criterion:** the `content_hash` values include the `args_hash`/`output_hash` printed above — the WORM blob id is exactly `sha256(plaintext)`, the same commitment already in the envelope.
+
+3. Confirm only ciphertext is stored — never plaintext or a bare key:
+   ```bash
+   docker compose exec bank-a-proxy sh -c "sqlite3 /data/bank-a.db 'SELECT ciphertext, wrapped_deks FROM content_blobs LIMIT 1;'" 2>/dev/null \
+     || sqlite3 ./bank-a.db.tmp "SELECT ciphertext, wrapped_deks FROM content_blobs LIMIT 1;"
+   ```
+   `ciphertext` must be opaque hex (not recognizable plaintext/JSON); `wrapped_deks` must be a JSON object of `{iv, ciphertext, tag}` entries per holder — never a raw key.
+
+4. **Cross-hold.** The same encrypted record must also be retrievable from the witness:
+   ```bash
+   curl -s "http://localhost:3003/blob/<CONTENT_HASH>" | python3 -m json.tool
+   ```
+   **PASS criterion:** 200, with `ciphertext`/`iv`/`tag` identical to Bank-A's local row — content is cross-held on ≥2 independent stores (Bank-A + TrustAgentAI), not just locally.
+
+5. **Write-once (WORM) rejection.** Re-`PUT` the same content hash with different ciphertext:
+   ```bash
+   curl -s -o /dev/null -w "%{http_code}\n" -X PUT "http://localhost:3003/blob/<CONTENT_HASH>" \
+     -H 'content-type: application/json' -d '{"ciphertext":"00","iv":"00","tag":"00","wrappedDeks":{}}'
+   ```
+   **PASS criterion:** non-2xx (409) — a second write under the same content hash with different bytes is refused. Re-`PUT`-ting the exact same body from step 4 must instead return 200 with `created:false` (idempotent).
+
+6. **Escrow (Decision #11 / DISPUTE §5.4).** No running key material exists to hand a QA agent for this — that is the point of the design. Exercise it via the unit tests instead:
+   ```bash
+   cd /home/ikarin/Trust-Agent/trust-agent && npx vitest run src/worm-store.test.ts
+   ```
+   **PASS criterion:** all pass, including `"lets the regulator unwrap the escrow entry but not the witness"`.
+
+7. Confirm the witness's own environment never has the escrow key:
+   ```bash
+   docker compose exec trust-agent-cloud sh -c 'env | grep -i escrow' || true
+   ```
+   **PASS criterion:** empty output — escrow is not held by TrustAgentAI.
+
+8. `verifyChain` is unaffected (WORM storage is additive, not a chain change):
+   ```bash
+   curl -s http://localhost:3001/verify-chain | python3 -m json.tool   # still {"valid": true}
+   curl -s http://localhost:3003/verify-chain | python3 -m json.tool   # still {"valid": true}
+   ```
+
 ## Part 4 — Force the on-chain anchor and verify it for real
 
 1. Trigger an immediate anchor of whatever's pending (don't wait for the auto-batch threshold):
@@ -265,7 +328,7 @@ The anchor now also anchors each party's **chain HEAD checkpoint** (`{party, hea
 ```bash
 curl -s "http://localhost:3002/dispute/<id — see /dispute/:id route in Bank-B/proxy/src/server.ts>" | python3 -m json.tool
 ```
-Confirm it returns a coherent bundle (envelopes + Merkle proof) for the transaction you drove, and that `args`/`output` fields are hashes only, not raw plaintext (that's expected/by-design for this stage — Delta #5 is what would change it, not in scope here).
+Confirm it returns a coherent bundle (envelopes + Merkle proof) for the transaction you drove. The pack itself still carries only hashes (`args_hash`/`output_hash`) — recovering the plaintext they commit to is the WORM store's job (Part 3d), fetched separately by a holder, not inlined into this bundle.
 
 ## Cleanup
 
@@ -286,5 +349,6 @@ Produce a single markdown report with:
 6. **Dispute pack** — confirm retrievable and internally consistent.
 7. **Witness co-sign (Delta #3)** — `COSIGN` present for the trace, witness `/verify-chain` valid + gapless `cosigns` rows, witness key durable across restart with no leaked private material, and the finality-gate result (transaction rejected while the witness was down).
 8. **Checkpoint & heartbeat (Delta #4)** — HEAD checkpoint anchored (tx on-chain, data = commitment), idempotent no-op on unchanged head, gapless `checkpoints`; heartbeats chain + increment with confirmed txs.
-9. **Overall verdict** — PASS/FAIL per section, and an explicit note that this run validates Delta #1 (key custody), Delta #2 (hash-chain), Delta #3 (inline co-sign witness + finality gate), Delta #4 (chain HEAD checkpoint + on-chain heartbeat), plus the pre-existing anchor pipeline; it does **not** exercise Deltas #5–7 (WORM content store, key-transparency, degraded-mode) since those aren't implemented yet — say so plainly rather than implying broader coverage than what ran. Residual (by design, DISPUTE_HARDENING §5.3): "TrustAgentAI + one bank colluding" is **not** closed. Delta #4 narrows §5.2 (a heartbeat gap now makes anchor/witness downtime publicly provable) but full degraded-mode discipline (reconciliation window + value cap) is Delta #7.
-8. Any CRITICAL findings called out at the very top, before the section-by-section detail.
+9. **WORM content store (Delta #5)** — content-address == envelope commitment (DoD #1), only ciphertext + wrapped-DEKs ever at rest, cross-held on Bank-A + witness, write-once rejection of a differing PUT under an existing hash (with idempotent accept of the identical one), escrow unit test result, and confirmation the witness's own env never holds the escrow key.
+10. **Overall verdict** — PASS/FAIL per section, and an explicit note that this run validates Delta #1 (key custody), Delta #2 (hash-chain), Delta #3 (inline co-sign witness + finality gate), Delta #4 (chain HEAD checkpoint + on-chain heartbeat), Delta #5 (WORM content store + envelope-encryption), plus the pre-existing anchor pipeline; it does **not** exercise Deltas #6–7 (key-transparency registry, degraded-mode discipline) since those aren't implemented yet — say so plainly rather than implying broader coverage than what ran. Residual (by design, DISPUTE_HARDENING §5.3): "TrustAgentAI + one bank colluding" is **not** closed. Delta #4 narrows §5.2 (a heartbeat gap now makes anchor/witness downtime publicly provable) but full degraded-mode discipline (reconciliation window + value cap) is Delta #7. Delta #5's holder-KEK model is still a pre-shared symmetric secret (same simplification as every other KEK in this repo) — Bank-A, as plaintext origin, ends up holding the witness's and client's content-KEK values too in order to wrap their DEK copies; note this as a residual, not a regression, since no confidentiality is lost versus the pre-Delta-5 baseline (Bank-A always had the plaintext).
+11. Any CRITICAL findings called out at the very top, before the section-by-section detail.

--- a/trust-agent-cloud/src/blob-db.test.ts
+++ b/trust-agent-cloud/src/blob-db.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { tmpdir } from "os";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import { initBlobDb, putBlob, getBlob, clearBlobs } from "./blob-db.js";
+
+const sampleBlob = {
+  ciphertext: "aa",
+  iv: "bb",
+  tag: "cc",
+  wrappedDeks: { witness: { iv: "1", ciphertext: "2", tag: "3" } },
+};
+
+beforeEach(() => {
+  initBlobDb(join(tmpdir(), `blob-db-test-${randomUUID()}.db`));
+  clearBlobs();
+});
+
+describe("putBlob / getBlob (WORM)", () => {
+  it("stores a new blob and reports it as created", () => {
+    const { blob, created } = putBlob("hash-1", sampleBlob);
+    expect(created).toBe(true);
+    expect(blob.contentHash).toBe("hash-1");
+    expect(getBlob("hash-1")).toEqual(blob);
+  });
+
+  it("is idempotent when the same id is re-put with identical content", () => {
+    putBlob("hash-1", sampleBlob);
+    const { created } = putBlob("hash-1", sampleBlob);
+    expect(created).toBe(false);
+  });
+
+  it("rejects a re-put of the same id with different content", () => {
+    putBlob("hash-1", sampleBlob);
+    expect(() => putBlob("hash-1", { ...sampleBlob, ciphertext: "different" })).toThrow();
+  });
+
+  it("returns undefined for a content hash that was never stored", () => {
+    expect(getBlob("missing")).toBeUndefined();
+  });
+});

--- a/trust-agent-cloud/src/blob-db.ts
+++ b/trust-agent-cloud/src/blob-db.ts
@@ -1,0 +1,99 @@
+/**
+ * TrustAgentAI Cloud — WORM blob store (Delta #5)
+ *
+ * Persists content-addressed, encrypted blobs pushed by the banks: ciphertext
+ * plus each holder's wrapped DEK. The witness NEVER receives plaintext or a
+ * bare DEK — only what's needed to (a) serve the encrypted blob back to a
+ * holder who can unwrap their own DEK, and (b) enforce write-once: a repeat
+ * PUT for the same content hash is idempotent if byte-identical, and rejected
+ * if the content differs (see `@trustagentai/a2a-core`'s `WormBlobStore` for
+ * the same invariant applied in-memory; this is its SQLite-backed twin so the
+ * witness's blob store survives restarts like its cosign chain does).
+ */
+
+import Database from "better-sqlite3";
+
+let db: Database.Database;
+
+interface WrappedDek {
+  iv: string;
+  ciphertext: string;
+  tag: string;
+}
+
+export interface StoredBlob {
+  contentHash: string;
+  ciphertext: string;
+  iv: string;
+  tag: string;
+  wrappedDeks: Record<string, WrappedDek>;
+}
+
+export function initBlobDb(path: string): void {
+  db = new Database(path, { timeout: 5000 });
+  db.pragma("journal_mode = WAL");
+  db.pragma("busy_timeout = 5000");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS blobs (
+      content_hash TEXT PRIMARY KEY,
+      ciphertext TEXT NOT NULL,
+      iv TEXT NOT NULL,
+      tag TEXT NOT NULL,
+      wrapped_deks TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+  `);
+}
+
+function toStoredBlob(r: any): StoredBlob {
+  return {
+    contentHash: r.content_hash,
+    ciphertext: r.ciphertext,
+    iv: r.iv,
+    tag: r.tag,
+    wrappedDeks: JSON.parse(r.wrapped_deks),
+  };
+}
+
+function serializeContent(b: Pick<StoredBlob, "ciphertext" | "iv" | "tag" | "wrappedDeks">): string {
+  return JSON.stringify({ ciphertext: b.ciphertext, iv: b.iv, tag: b.tag, wrappedDeks: b.wrappedDeks });
+}
+
+export interface PutBlobResult {
+  blob: StoredBlob;
+  created: boolean;
+}
+
+export type BlobInput = Pick<StoredBlob, "ciphertext" | "iv" | "tag" | "wrappedDeks">;
+
+/**
+ * Write-once put: a first write for `contentHash` inserts the row; a repeat
+ * write with byte-identical ciphertext/iv/tag/wrappedDeks is a no-op; a
+ * repeat write with any difference throws (WORM violation).
+ */
+export function putBlob(contentHash: string, blob: BlobInput): PutBlobResult {
+  const existingRow = db.prepare("SELECT * FROM blobs WHERE content_hash = ?").get(contentHash) as any;
+  if (existingRow) {
+    const existing = toStoredBlob(existingRow);
+    if (serializeContent(existing) === serializeContent(blob)) {
+      return { blob: existing, created: false };
+    }
+    throw new Error(`WORM violation: blob ${contentHash} already stored with different content`);
+  }
+
+  db.prepare(
+    "INSERT INTO blobs (content_hash, ciphertext, iv, tag, wrapped_deks, created_at) VALUES (?, ?, ?, ?, ?, ?)"
+  ).run(contentHash, blob.ciphertext, blob.iv, blob.tag, JSON.stringify(blob.wrappedDeks), new Date().toISOString());
+
+  return { blob: { contentHash, ...blob }, created: true };
+}
+
+export function getBlob(contentHash: string): StoredBlob | undefined {
+  const row = db.prepare("SELECT * FROM blobs WHERE content_hash = ?").get(contentHash) as any;
+  return row ? toStoredBlob(row) : undefined;
+}
+
+/** Drop all blob rows (demo /reset and tests). */
+export function clearBlobs(): void {
+  db.exec("DELETE FROM blobs");
+}

--- a/trust-agent-cloud/src/server.ts
+++ b/trust-agent-cloud/src/server.ts
@@ -18,6 +18,7 @@ import { loadOrCreateKeyPair } from "@trustagentai/a2a-core";
 import type { IntentEnvelope, AcceptanceReceipt } from "@trustagentai/a2a-core";
 import { initDb, verifyCoSignChain, clearCoSigns } from "./db.js";
 import { CoSignService } from "./witness.js";
+import { initBlobDb, putBlob, getBlob, clearBlobs, type BlobInput } from "./blob-db.js";
 
 const PORT = Number(process.env.PORT ?? 3003);
 const DB_PATH = process.env.DB_PATH ?? "/data/trust-agent-cloud.db";
@@ -31,6 +32,7 @@ async function main(): Promise<void> {
   }
   const witnessKey = await loadOrCreateKeyPair(WITNESS_KID, KEYSTORE_PATH, KEYSTORE_KEK);
   initDb(DB_PATH);
+  initBlobDb(DB_PATH);
   const service = new CoSignService(witnessKey);
 
   const app = express();
@@ -79,8 +81,37 @@ async function main(): Promise<void> {
 
   app.get("/verify-chain", (_req, res) => res.json(verifyCoSignChain()));
 
+  // Delta #5: WORM content store. The witness is one of the cross-held
+  // copies of the encrypted (never plaintext) transaction content — it only
+  // ever sees ciphertext + wrapped DEKs, and its own wrapped-DEK entry is the
+  // only one it could ever unwrap.
+  app.put("/blob/:contentHash", (req, res) => {
+    const { contentHash } = req.params;
+    const blob = req.body as BlobInput;
+    if (!blob?.ciphertext || !blob?.iv || !blob?.tag || !blob?.wrappedDeks) {
+      res.status(400).json({ error: "ciphertext, iv, tag, and wrappedDeks are required" });
+      return;
+    }
+    try {
+      const { created } = putBlob(contentHash, blob);
+      res.status(created ? 201 : 200).json({ ok: true, created });
+    } catch (err) {
+      res.status(409).json({ error: String(err) });
+    }
+  });
+
+  app.get("/blob/:contentHash", (req, res) => {
+    const blob = getBlob(req.params.contentHash);
+    if (!blob) {
+      res.status(404).json({ error: "blob not found" });
+      return;
+    }
+    res.json(blob);
+  });
+
   app.post("/reset", (_req, res) => {
     clearCoSigns();
+    clearBlobs();
     res.json({ ok: true });
   });
 

--- a/trust-agent-cloud/vitest.config.ts
+++ b/trust-agent-cloud/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],
-      include: ["src/db.ts", "src/witness.ts"],
+      include: ["src/db.ts", "src/witness.ts", "src/blob-db.ts"],
       thresholds: {
         lines: 80,
         functions: 80,

--- a/trust-agent/src/index.ts
+++ b/trust-agent/src/index.ts
@@ -9,3 +9,5 @@ export * from "./ledger.js";
 export * from "./nonce-registry.js";
 export * from "./risk-budget.js";
 export * from "./trust-proxy.js";
+export * from "./worm.js";
+export * from "./worm-store.js";

--- a/trust-agent/src/worm-store.test.ts
+++ b/trust-agent/src/worm-store.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { contentAddress } from "./worm.js";
+import { buildWormRecord, decryptWormRecord, WormBlobStore } from "./worm-store.js";
+import type { Holder } from "./worm-store.js";
+
+const bankA: Holder = { id: "bank-a", kek: Buffer.from("1".repeat(64), "hex") };
+const client: Holder = { id: "client", kek: Buffer.from("2".repeat(64), "hex") };
+const witness: Holder = { id: "witness", kek: Buffer.from("3".repeat(64), "hex") };
+const regulator: Holder = { id: "regulator", kek: Buffer.from("4".repeat(64), "hex") };
+
+describe("buildWormRecord / decryptWormRecord", () => {
+  it("addresses the record by sha256(plaintext) (DoD #1)", () => {
+    const plaintext = Buffer.from(JSON.stringify({ amount: 250 }));
+    const record = buildWormRecord(plaintext, [bankA, client, witness], regulator);
+    expect(record.contentHash).toBe(contentAddress(plaintext));
+  });
+
+  it("lets every registered holder decrypt back the original plaintext", () => {
+    const plaintext = Buffer.from("full transaction description");
+    const record = buildWormRecord(plaintext, [bankA, client, witness], regulator);
+
+    for (const holder of [bankA, client, witness]) {
+      expect(decryptWormRecord(record, holder.id, holder.kek).equals(plaintext)).toBe(true);
+    }
+  });
+
+  it("throws for a holder id that has no wrapped DEK on the record", () => {
+    const record = buildWormRecord(Buffer.from("x"), [bankA], regulator);
+    expect(() => decryptWormRecord(record, "client", client.kek)).toThrow();
+  });
+
+  it("lets the regulator unwrap the escrow entry but not the witness", () => {
+    const plaintext = Buffer.from("dispute pack content");
+    const record = buildWormRecord(plaintext, [bankA, client, witness], regulator);
+
+    expect(decryptWormRecord(record, "regulator", regulator.kek).equals(plaintext)).toBe(true);
+    // The witness's own KEK must not unlock the escrow entry (§5.4 — escrow is
+    // NOT held by TrustAgentAI).
+    expect(() => decryptWormRecord(record, "regulator", witness.kek)).toThrow();
+  });
+});
+
+describe("WormBlobStore (write-once)", () => {
+  const store = () => new WormBlobStore<{ v: string }>((r) => JSON.stringify(r));
+
+  it("stores a new id and reports it as created", () => {
+    const s = store();
+    const { record, created } = s.put("id-1", { v: "a" });
+    expect(created).toBe(true);
+    expect(record).toEqual({ v: "a" });
+    expect(s.get("id-1")).toEqual({ v: "a" });
+  });
+
+  it("is idempotent when the same id is written with byte-identical content", () => {
+    const s = store();
+    s.put("id-1", { v: "a" });
+    const { record, created } = s.put("id-1", { v: "a" });
+    expect(created).toBe(false);
+    expect(record).toEqual({ v: "a" });
+  });
+
+  it("rejects writing different content under an already-used id", () => {
+    const s = store();
+    s.put("id-1", { v: "a" });
+    expect(() => s.put("id-1", { v: "b" })).toThrow();
+  });
+
+  it("returns undefined for an id that was never written", () => {
+    expect(store().get("missing")).toBeUndefined();
+  });
+});

--- a/trust-agent/src/worm-store.ts
+++ b/trust-agent/src/worm-store.ts
@@ -1,0 +1,109 @@
+/**
+ * TrustAgentAI — WORM blob records + write-once store (Delta #5)
+ *
+ * `buildWormRecord` assembles the encrypted, content-addressed record for one
+ * transaction's plaintext (args or output): a fresh per-tx DEK encrypts the
+ * content once, then the SAME DEK is wrapped (envelope-encrypted) once per
+ * holder KEK — including a separate regulator escrow entry. No holder ever
+ * sees another holder's key material, and none of them see the DEK itself
+ * except through their own wrapped copy.
+ *
+ * `WormBlobStore` is the generic write-once keyed store used both locally
+ * (proxies) and remotely (the witness's `/blob` endpoint): a given id may be
+ * written once; a repeat write of byte-identical content is a no-op, and a
+ * repeat write of DIFFERENT content under the same id is a WORM violation.
+ */
+
+import { contentAddress, encryptContent, decryptContent, wrapDek, unwrapDek, generateDek } from "./worm.js";
+import type { EncryptedBlob, WrappedKey } from "./worm.js";
+
+/** A party who may independently decrypt WORM content, identified by id. */
+export interface Holder {
+  id: string;
+  kek: Buffer;
+}
+
+/** The full encrypted record for one piece of plaintext, cross-holdable. */
+export interface WormBlobRecord {
+  contentHash: string;
+  ciphertext: string;
+  iv: string;
+  tag: string;
+  wrappedDeks: Record<string, WrappedKey>;
+}
+
+/**
+ * Encrypt `plaintext` under a fresh DEK and wrap that DEK for every holder
+ * plus a separate escrow holder (regulator). `contentHash` is `sha256(plaintext)`
+ * — the same commitment already carried as `args_hash`/`output_hash` in the
+ * envelope (DoD #1).
+ */
+export function buildWormRecord(
+  plaintext: Buffer,
+  holders: readonly Holder[],
+  escrow: Holder
+): WormBlobRecord {
+  const contentHash = contentAddress(plaintext);
+  const dek = generateDek();
+  const enc: EncryptedBlob = encryptContent(plaintext, dek);
+
+  const wrappedDeks: Record<string, WrappedKey> = {};
+  for (const holder of holders) {
+    wrappedDeks[holder.id] = wrapDek(dek, holder.kek);
+  }
+  wrappedDeks[escrow.id] = wrapDek(dek, escrow.kek);
+
+  return { contentHash, ciphertext: enc.ciphertext, iv: enc.iv, tag: enc.tag, wrappedDeks };
+}
+
+/**
+ * Decrypt a WORM record as a given holder. Throws if the holder has no
+ * wrapped DEK on this record, if the KEK is wrong (GCM auth failure on
+ * unwrap), or if the recovered plaintext no longer matches `contentHash`.
+ */
+export function decryptWormRecord(record: WormBlobRecord, holderId: string, kek: Buffer): Buffer {
+  const wrapped = record.wrappedDeks[holderId];
+  if (!wrapped) throw new Error(`holder "${holderId}" has no wrapped DEK on this record`);
+
+  const dek = unwrapDek(wrapped, kek);
+  const plaintext = decryptContent({ ciphertext: record.ciphertext, iv: record.iv, tag: record.tag }, dek);
+
+  if (contentAddress(plaintext) !== record.contentHash) {
+    throw new Error("decrypted content does not match the record's content hash");
+  }
+  return plaintext;
+}
+
+export interface WormPutResult<T> {
+  record: T;
+  created: boolean;
+}
+
+/**
+ * Generic write-once store keyed by content id. First write wins; a repeat
+ * write with byte-identical (serialized) content is idempotent; a repeat
+ * write with DIFFERENT content under the same id is rejected — the WORM
+ * invariant, enforced whether the id came from a locally-computed content
+ * hash or a caller-declared one (e.g. an HTTP `PUT /blob/:contentHash`).
+ */
+export class WormBlobStore<T> {
+  private readonly records = new Map<string, T>();
+
+  constructor(private readonly serialize: (record: T) => string) {}
+
+  put(id: string, record: T): WormPutResult<T> {
+    const existing = this.records.get(id);
+    if (existing !== undefined) {
+      if (this.serialize(existing) === this.serialize(record)) {
+        return { record: existing, created: false };
+      }
+      throw new Error(`WORM violation: "${id}" already stored with different content`);
+    }
+    this.records.set(id, record);
+    return { record, created: true };
+  }
+
+  get(id: string): T | undefined {
+    return this.records.get(id);
+  }
+}

--- a/trust-agent/src/worm.test.ts
+++ b/trust-agent/src/worm.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { sha256Json } from "./crypto.js";
+import {
+  generateDek,
+  canonicalBytes,
+  contentAddress,
+  encryptContent,
+  decryptContent,
+  wrapDek,
+  unwrapDek,
+} from "./worm.js";
+
+const holderKek = Buffer.from("a".repeat(64), "hex");
+const otherKek = Buffer.from("b".repeat(64), "hex");
+
+describe("generateDek", () => {
+  it("returns a fresh 32-byte key on every call", () => {
+    const dek1 = generateDek();
+    const dek2 = generateDek();
+    expect(dek1).toHaveLength(32);
+    expect(Buffer.from(dek1).equals(Buffer.from(dek2))).toBe(false);
+  });
+});
+
+describe("contentAddress / canonicalBytes (DoD #1)", () => {
+  it("equals sha256Json(value) when applied to the value's canonical bytes", () => {
+    const value = { amount: 100, note: "wire transfer" };
+    expect(contentAddress(canonicalBytes(value))).toBe(sha256Json(value));
+  });
+});
+
+describe("encryptContent / decryptContent", () => {
+  it("round-trips plaintext through AES-256-GCM", () => {
+    const dek = generateDek();
+    const plaintext = Buffer.from("full transaction description");
+    const blob = encryptContent(plaintext, dek);
+    expect(decryptContent(blob, dek).equals(plaintext)).toBe(true);
+  });
+
+  it("fails to decrypt on a tampered ciphertext (GCM auth failure)", () => {
+    const dek = generateDek();
+    const blob = encryptContent(Buffer.from("secret"), dek);
+    const tampered = { ...blob, ciphertext: Buffer.from(blob.ciphertext, "hex").map((b, i) => (i === 0 ? b ^ 0xff : b)).toString("hex") };
+    expect(() => decryptContent(tampered, dek)).toThrow();
+  });
+
+  it("fails to decrypt with the wrong DEK", () => {
+    const blob = encryptContent(Buffer.from("secret"), generateDek());
+    expect(() => decryptContent(blob, generateDek())).toThrow();
+  });
+});
+
+describe("wrapDek / unwrapDek", () => {
+  it("round-trips a DEK under a holder KEK", () => {
+    const dek = generateDek();
+    const wrapped = wrapDek(dek, holderKek);
+    expect(Buffer.from(unwrapDek(wrapped, holderKek)).equals(Buffer.from(dek))).toBe(true);
+  });
+
+  it("fails to unwrap under the wrong KEK", () => {
+    const wrapped = wrapDek(generateDek(), holderKek);
+    expect(() => unwrapDek(wrapped, otherKek)).toThrow();
+  });
+});

--- a/trust-agent/src/worm.ts
+++ b/trust-agent/src/worm.ts
@@ -1,0 +1,70 @@
+/**
+ * TrustAgentAI — WORM content encryption primitives (Delta #5)
+ *
+ * Pure crypto for the content-addressed, envelope-encrypted WORM store:
+ * generate a per-transaction DEK, encrypt/decrypt content under it (reusing
+ * the AES-256-GCM pattern from crypto.ts's keystore), and wrap/unwrap that
+ * DEK under a holder's KEK so multiple parties can each independently
+ * decrypt without ever sharing the DEK in the clear. Storage/wiring lives in
+ * `worm-store.ts` and the service layers; this module has no I/O.
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes, createHash } from "crypto";
+import _canonicalize = require("canonicalize");
+const canonicalize = (_canonicalize.default ?? _canonicalize) as (input: unknown) => string | undefined;
+
+export interface EncryptedBlob {
+  iv: string;         // hex, 12 bytes
+  ciphertext: string; // hex
+  tag: string;        // hex, GCM auth tag
+}
+
+/** A DEK wrapped (encrypted) under one holder's KEK. Same shape as EncryptedBlob. */
+export type WrappedKey = EncryptedBlob;
+
+/** Fresh random 256-bit content-encryption key, one per transaction. */
+export function generateDek(): Uint8Array {
+  return randomBytes(32);
+}
+
+/**
+ * JCS-canonical UTF-8 bytes of a JSON-serializable value. Hashing these bytes
+ * with {@link contentAddress} reproduces `sha256Json(value)` from crypto.ts —
+ * the value already committed as `args_hash`/`output_hash` in the envelope.
+ */
+export function canonicalBytes(value: unknown): Buffer {
+  const canonical = canonicalize(value);
+  if (!canonical) throw new Error("JCS canonicalization failed");
+  return Buffer.from(canonical, "utf8");
+}
+
+/** Content address of raw bytes: hex SHA-256. This is the WORM blob id. */
+export function contentAddress(plaintext: Buffer): string {
+  return createHash("sha256").update(plaintext).digest("hex");
+}
+
+/** Encrypt content under a DEK with AES-256-GCM (random IV, authenticated). */
+export function encryptContent(plaintext: Buffer, dek: Uint8Array): EncryptedBlob {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", Buffer.from(dek), iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return { iv: iv.toString("hex"), ciphertext: ciphertext.toString("hex"), tag: tag.toString("hex") };
+}
+
+/** Decrypt content encrypted by {@link encryptContent}. Throws on tamper or wrong DEK. */
+export function decryptContent(blob: EncryptedBlob, dek: Uint8Array): Buffer {
+  const decipher = createDecipheriv("aes-256-gcm", Buffer.from(dek), Buffer.from(blob.iv, "hex"));
+  decipher.setAuthTag(Buffer.from(blob.tag, "hex"));
+  return Buffer.concat([decipher.update(Buffer.from(blob.ciphertext, "hex")), decipher.final()]);
+}
+
+/** Wrap (encrypt) a DEK under a holder's KEK — envelope-encryption. */
+export function wrapDek(dek: Uint8Array, kek: Buffer): WrappedKey {
+  return encryptContent(Buffer.from(dek), kek);
+}
+
+/** Unwrap a DEK wrapped by {@link wrapDek}. Throws on tamper or wrong KEK. */
+export function unwrapDek(wrapped: WrappedKey, kek: Buffer): Uint8Array {
+  return new Uint8Array(decryptContent(wrapped, kek));
+}

--- a/trust-agent/vitest.config.ts
+++ b/trust-agent/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],
-      include: ["src/crypto.ts", "src/hash-chain.ts", "src/co-sign.ts"],
+      include: ["src/crypto.ts", "src/hash-chain.ts", "src/co-sign.ts", "src/worm.ts", "src/worm-store.ts"],
       thresholds: {
         lines: 80,
         functions: 80,


### PR DESCRIPTION
## Summary

Implements Delta #5 from `docs/execution_plan.md` §5: `args`/`outputData` are no longer discarded (previously *"hashed, NOT stored"*) — they're now persisted as **encrypted, content-addressed WORM blobs**, cross-held so *what* happened survives a two-bank collusion (DISPUTE_HARDENING Decisions #5 & #11).

Note on base branch: `feat/delta-4-anchoring` (PR #21's head) was deleted upstream after merging into `feat/delta-3-cosign` (its actual PR base, per the original stacking plan). This PR is rebased onto the current `feat/delta-3-cosign`, which now contains everything through Delta #4 — the diff below is Delta #5 only.

- **`trust-agent/src/worm.ts`** — pure crypto: per-tx DEK generation, `contentAddress`/`canonicalBytes` (blob id = `sha256(plaintext)` = the commitment already in the envelope, DoD #1), AES-256-GCM encrypt/decrypt (reusing the `crypto.ts` keystore pattern), wrap/unwrap a DEK under a holder KEK.
- **`trust-agent/src/worm-store.ts`** — `buildWormRecord`/`decryptWormRecord` (wraps one DEK per holder + a separate regulator escrow entry), `WormBlobStore` (generic write-once store: idempotent on identical re-put, rejects a differing one).
- **`trust-agent-cloud`** — `PUT`/`GET /blob/:contentHash`, SQLite-backed (`blob-db.ts`), same write-once invariant. The witness's env never reads an escrow KEK — it can only ever unwrap its own holder entry (Decision #11 / DISPUTE §5.4: escrow is NOT held by TrustAgentAI).
- **Bank-A `/invoke`** — encrypts `args`/`outputData` after execution, stores locally (`worm-db.ts`), best-effort cross-pushes the encrypted record (never plaintext/DEK) to the witness. Content-KEKs are optional env vars; missing any of them skips WORM storage with a warning rather than breaking the existing flow (additive, wire-compatible).
- `.env.example` + `docker-compose.yml` updated with the 4 new placeholder KEKs.
- `docs/testing/E2E_ANTIGRAVITY_PROMPT.md` — new Part 3d covering DoD #1, ciphertext-only-at-rest, cross-hold, write-once rejection, and the escrow/witness-env check.

## Tests + coverage (TDD, RED confirmed before each impl)

- `trust-agent`: 49/49 passing. New modules — `worm.ts` 94%/75%/100%/100%, `worm-store.ts` 96%/87%/100%/96% (stmt/branch/func/line).
- `trust-agent-cloud`: 11/11 passing. `blob-db.ts` 100%/100%/100%/100%.
- All ≥80% threshold. `trust-agent`, `trust-agent-cloud`, `Bank-A/proxy`, `Bank-B/proxy` all build clean (`tsc`), re-verified after the rebase.
- Covers the plan's full test list: encrypt↔decrypt round-trip, tamper/wrong-DEK GCM auth failure, content-address == commitment, wrap/unwrap round-trip + wrong-KEK failure, escrow unwraps for the regulator but not the witness, WORM write-once (idempotent/reject).

## Residual risks (carried forward, not regressions)

- **Content-KEKs are pre-shared symmetric secrets** (same simplification as every other KEK in this repo, e.g. `KEYSTORE_KEK`) — Bank-A, as plaintext origin, holds the witness's and client's content-KEK values too, in order to wrap their DEK copies. No confidentiality loss vs. the pre-Delta-5 baseline (Bank-A always had the plaintext). Real per-holder asymmetric envelope-encryption is future work.
- **"Client" holder has no independent running store** — its DEK is wrapped (so the wire format anticipates it), but there's no client-side service in this repo to push the encrypted blob to. Cross-hold is currently Bank-A (local) + TrustAgentAI witness (remote) — 2 independent copies, meeting the "≥2 holders" acceptance bar, but not yet the full "TrustAgentAI + client + banks" end state from DISPUTE_HARDENING Decision #5.
- **Escrow (Decision #11 / §5.4) is honored**: `REGULATOR_ESCROW_KEK` is never read by `trust-agent-cloud`, verified by an explicit env-grep check in the E2E prompt and by the `worm-store.test.ts` case that the witness's own KEK cannot unwrap the escrow entry.

## Next (Delta #6–7, not in this PR)

- **Delta #6** — key-transparency registry (replace mutable `register-peer-key` with an append-only, anchored one; validity windows; rotation endorsed by prior key).
- **Delta #7** — degraded-mode discipline (heartbeat-gap detection, reconciliation window, value/rate cap on degraded transactions).

## Test plan

- [x] `cd trust-agent && npm run build && npm run test:coverage`
- [x] `cd trust-agent-cloud && npm run build && npm run test:coverage`
- [x] `cd Bank-A/proxy && npm run build`
- [x] `cd Bank-B/proxy && npm run build`
- [ ] Full `docker-compose` E2E run (Part 3d of the updated prompt) — not run in this session; hand off to the E2E harness per `docs/testing/E2E_ANTIGRAVITY_PROMPT.md`.