### PR TITLE
feat: append-only key-transparency registry (Delta #6)

### DIFF
--- a/Bank-B/proxy/src/server.ts
+++ b/Bank-B/proxy/src/server.ts
@@ -7,9 +7,13 @@ import {
   DAGLedger,
   NonceRegistry,
   RiskBudgetEngine,
+  KeyRegistry,
+  didFromKid,
+  type PublicKeySource,
   type IntentEnvelope,
   type ExecutionEnvelope,
   type KeyPair,
+  type SignatureBlock,
   signEnvelope,
 } from "@trustagentai/a2a-core";
 import { 
@@ -63,7 +67,7 @@ let nonceRegistry: NonceRegistry;
 let budgetEngine: RiskBudgetEngine;
 let proxyB: ProxyBGateway;
 
-function initProxyB(proxyBKey: KeyPair, proxyAPublicKeys: Map<string, Uint8Array>) {
+function initProxyB(proxyBKey: KeyPair, proxyAPublicKeys: PublicKeySource) {
   ledger = new DAGLedger();
   nonceRegistry = new NonceRegistry();
   budgetEngine = new RiskBudgetEngine();
@@ -94,7 +98,7 @@ async function main(): Promise<void> {
   initDb(DB_PATH);
   const sseBus = new SseBus();
 
-  const proxyAPublicKeys = new Map<string, Uint8Array>();
+  const proxyAPublicKeys = new KeyRegistry();
   initProxyB(proxyKey, proxyAPublicKeys);
 
   // Delta #3: register our key with the independent witness so it can verify
@@ -155,11 +159,63 @@ async function main(): Promise<void> {
 
   app.get("/health", (_req, res) => res.json({ ok: true }));
 
-  app.post("/register-peer-key", (req, res) => {
-    const { kid, publicKeyHex } = req.body as { kid: string; publicKeyHex: string };
-    proxyAPublicKeys.set(kid, Buffer.from(publicKeyHex, "hex"));
-    console.log(`[bank-b-proxy] registered peer key: ${kid}`);
-    res.json({ ok: true });
+  app.post("/register-peer-key", async (req, res) => {
+    const { kid, publicKeyHex, endorsement, timestamp } = req.body as {
+      kid?: string;
+      publicKeyHex?: string;
+      endorsement?: SignatureBlock;
+      /** Required alongside `endorsement` — the exact timestamp the caller
+       *  signed into the rotation attestation. */
+      timestamp?: string;
+    };
+    if (!kid || !publicKeyHex) {
+      res.status(400).json({ error: "kid and publicKeyHex are required" });
+      return;
+    }
+    if (endorsement && !timestamp) {
+      res.status(400).json({ error: "timestamp is required alongside endorsement" });
+      return;
+    }
+    try {
+      await proxyAPublicKeys.register(didFromKid(kid), kid, publicKeyHex, timestamp ?? new Date().toISOString(), endorsement);
+      console.log(`[bank-b-proxy] registered peer key: ${kid}`);
+      res.json({ ok: true });
+    } catch (err) {
+      console.warn(`[bank-b-proxy] key registration refused for ${kid}`, err);
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  // Delta #6: revoke the currently active key for a DID (any of its kids),
+  // and read back its full epoch history (the transparency log).
+  app.post("/revoke-peer-key", async (req, res) => {
+    const { kid, endorsement, timestamp } = req.body as {
+      kid?: string;
+      endorsement?: SignatureBlock;
+      timestamp?: string;
+    };
+    if (!kid || !endorsement || !timestamp) {
+      res.status(400).json({ error: "kid, endorsement, and timestamp are required" });
+      return;
+    }
+    try {
+      await proxyAPublicKeys.revoke(didFromKid(kid), timestamp, endorsement);
+      console.log(`[bank-b-proxy] revoked key: ${kid}`);
+      res.json({ ok: true });
+    } catch (err) {
+      console.warn(`[bank-b-proxy] key revocation refused for ${kid}`, err);
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  app.get("/key-history/:kid", (req, res) => {
+    const history = proxyAPublicKeys.getHistory(didFromKid(req.params.kid)).map((e) => ({
+      kid: e.kid,
+      publicKeyHex: Buffer.from(e.publicKey).toString("hex"),
+      validFrom: e.validFrom,
+      validUntil: e.validUntil,
+    }));
+    res.json(history);
   });
 
   app.post("/reset", (_req, res) => {

--- a/docs/testing/E2E_ANTIGRAVITY_PROMPT.md
+++ b/docs/testing/E2E_ANTIGRAVITY_PROMPT.md
@@ -271,6 +271,54 @@ An independent service, **`trust-agent-cloud`** (port 3003), co-signs each trans
    curl -s http://localhost:3003/verify-chain | python3 -m json.tool   # still {"valid": true}
    ```
 
+## Part 3e — Key-transparency registry (Delta #6)
+
+`register-peer-key` (Bank-B) and `register-key` (witness) are no longer "last write wins": both are now backed by an append-only `KeyRegistry`. A DID's first registration is trust-on-first-use; any later one is a **rotation** and must be **endorsed** — signed by the DID's prior key. Revocation closes a key's validity window without deleting its history.
+
+1. **Bootstrap is unaffected (regression check).** The stack already registered both proxies' boot-time keys with each other and the witness in Startup — confirm those first-registrations still show up:
+   ```bash
+   curl -s http://localhost:3002/key-history/did:workload:bank-a-proxy#key-1 | python3 -m json.tool
+   curl -s http://localhost:3003/key-history/did:workload:bank-a-proxy#key-1 | python3 -m json.tool
+   ```
+   **PASS criterion:** one epoch each, `validUntil: null` (still active).
+
+2. **Endorsed rotation, live.** Generate a second Ed25519 keypair for Bank-A's DID and an endorsement signed by its *current* key — easiest via a short Node one-liner using the already-built package:
+   ```bash
+   docker compose exec bank-a-proxy node -e "
+   const { generateKeyPair, buildRotationAttestation, signRotation, loadOrCreateKeyPair } = require('@trustagentai/a2a-core');
+   (async () => {
+     const oldKey = await loadOrCreateKeyPair('did:workload:bank-a-proxy#key-1', '/data/bank-a-keystore.json', process.env.KEYSTORE_KEK);
+     const newKey = await generateKeyPair('did:workload:bank-a-proxy#key-2');
+     const newPubHex = Buffer.from(newKey.publicKey).toString('hex');
+     const ts = new Date().toISOString();
+     const attestation = buildRotationAttestation('did:workload:bank-a-proxy', newKey.kid, newPubHex, ts);
+     const endorsement = await signRotation(attestation, oldKey);
+     console.log(JSON.stringify({ kid: newKey.kid, publicKeyHex: newPubHex, timestamp: ts, endorsement }));
+   })();
+   "
+   ```
+   POST the printed JSON to both registries:
+   ```bash
+   curl -s -X POST http://localhost:3002/register-peer-key -H 'content-type: application/json' -d '<PRINTED_JSON>'
+   curl -s -X POST http://localhost:3003/register-key -H 'content-type: application/json' -d '<PRINTED_JSON>'
+   ```
+   **PASS criterion:** both `{"ok":true}`. Then:
+   ```bash
+   curl -s http://localhost:3002/key-history/did:workload:bank-a-proxy#key-1 | python3 -m json.tool
+   ```
+   The `#key-1` epoch now has a non-null `validUntil`; a `GET .../key-history/did:workload:bank-a-proxy#key-2` shows the new epoch with `validUntil: null`. History is additive — nothing was deleted or overwritten.
+
+3. **Unendorsed / badly-endorsed rotation is rejected.** Repeat step 2's POST but omit `endorsement`, or reuse a stale/mismatched one:
+   ```bash
+   curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:3002/register-peer-key \
+     -H 'content-type: application/json' -d '{"kid":"did:workload:bank-a-proxy#key-3","publicKeyHex":"00"}'
+   ```
+   **PASS criterion:** `400` — a DID with an existing key cannot be silently overwritten. (Deterministic equivalent, no live stack needed: `cd trust-agent && npx vitest run src/key-registry.test.ts` — covers unendorsed, wrong-key-endorsed, and duplicate-kid-different-key rejection explicitly.)
+
+4. **Revocation-as-append.** Build `{did, revoke_kid, timestamp}` signed by the *currently active* key (same pattern as step 2, target `/revoke-peer-key` or `/revoke-key` with `{kid, endorsement, timestamp}`), then re-check `/key-history/:kid` — the active epoch's `validUntil` is now set, but the row is still present (not deleted), and the revoked key's own past signatures remain independently verifiable (only *new* registrations for that DID are now blocked without it).
+
+**Note:** rotating Bank-A's live signing key mid-run means subsequent `/invoke` calls sign with the *old* key unless the proxy process itself is restarted with a new keystore — this section proves the **registry's** append-only/endorsement mechanics, not an operational "rotate now" flow (that wiring is intentionally out of scope for this delta; see the PR's residual-risk note).
+
 ## Part 4 — Force the on-chain anchor and verify it for real
 
 1. Trigger an immediate anchor of whatever's pending (don't wait for the auto-batch threshold):
@@ -350,5 +398,6 @@ Produce a single markdown report with:
 7. **Witness co-sign (Delta #3)** — `COSIGN` present for the trace, witness `/verify-chain` valid + gapless `cosigns` rows, witness key durable across restart with no leaked private material, and the finality-gate result (transaction rejected while the witness was down).
 8. **Checkpoint & heartbeat (Delta #4)** — HEAD checkpoint anchored (tx on-chain, data = commitment), idempotent no-op on unchanged head, gapless `checkpoints`; heartbeats chain + increment with confirmed txs.
 9. **WORM content store (Delta #5)** — content-address == envelope commitment (DoD #1), only ciphertext + wrapped-DEKs ever at rest, cross-held on Bank-A + witness, write-once rejection of a differing PUT under an existing hash (with idempotent accept of the identical one), escrow unit test result, and confirmation the witness's own env never holds the escrow key.
-10. **Overall verdict** — PASS/FAIL per section, and an explicit note that this run validates Delta #1 (key custody), Delta #2 (hash-chain), Delta #3 (inline co-sign witness + finality gate), Delta #4 (chain HEAD checkpoint + on-chain heartbeat), Delta #5 (WORM content store + envelope-encryption), plus the pre-existing anchor pipeline; it does **not** exercise Deltas #6–7 (key-transparency registry, degraded-mode discipline) since those aren't implemented yet — say so plainly rather than implying broader coverage than what ran. Residual (by design, DISPUTE_HARDENING §5.3): "TrustAgentAI + one bank colluding" is **not** closed. Delta #4 narrows §5.2 (a heartbeat gap now makes anchor/witness downtime publicly provable) but full degraded-mode discipline (reconciliation window + value cap) is Delta #7. Delta #5's holder-KEK model is still a pre-shared symmetric secret (same simplification as every other KEK in this repo) — Bank-A, as plaintext origin, ends up holding the witness's and client's content-KEK values too in order to wrap their DEK copies; note this as a residual, not a regression, since no confidentiality is lost versus the pre-Delta-5 baseline (Bank-A always had the plaintext).
-11. Any CRITICAL findings called out at the very top, before the section-by-section detail.
+10. **Key-transparency registry (Delta #6)** — bootstrap registrations intact, an endorsed rotation accepted and visible in `/key-history` with the old epoch closed (`validUntil` set) and the new one open, an unendorsed/badly-endorsed rotation rejected (`400`), and revocation-as-append (epoch closed, not deleted).
+11. **Overall verdict** — PASS/FAIL per section, and an explicit note that this run validates Delta #1 (key custody), Delta #2 (hash-chain), Delta #3 (inline co-sign witness + finality gate), Delta #4 (chain HEAD checkpoint + on-chain heartbeat), Delta #5 (WORM content store + envelope-encryption), Delta #6 (append-only key-transparency registry), plus the pre-existing anchor pipeline; it does **not** exercise Delta #7 (degraded-mode discipline) since it isn't implemented yet — say so plainly rather than implying broader coverage than what ran. Residual (by design, DISPUTE_HARDENING §5.3): "TrustAgentAI + one bank colluding" is **not** closed. Delta #4 narrows §5.2 (a heartbeat gap now makes anchor/witness downtime publicly provable) but full degraded-mode discipline (reconciliation window + value cap) is Delta #7. Delta #5's holder-KEK model is still a pre-shared symmetric secret (same simplification as every other KEK in this repo) — Bank-A, as plaintext origin, ends up holding the witness's and client's content-KEK values too in order to wrap their DEK copies; note this as a residual, not a regression, since no confidentiality is lost versus the pre-Delta-5 baseline (Bank-A always had the plaintext). Delta #6 closes "whose key" repudiation for rotations but recovering a DID whose only key is lost/revoked (no prior key available to endorse a replacement) is an explicit, out-of-scope bootstrap problem — flag it if a reviewer asks about it, don't treat it as a bug.
+12. Any CRITICAL findings called out at the very top, before the section-by-section detail.

--- a/trust-agent-cloud/package-lock.json
+++ b/trust-agent-cloud/package-lock.json
@@ -23,6 +23,27 @@
         "vitest": "^4.1.9"
       }
     },
+    "../trust-agent": {
+      "name": "@trustagentai/a2a-core",
+      "version": "0.5.0-alpha.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/ed25519": "^2.1.0",
+        "canonicalize": "^2.0.0",
+        "uuid": "^10.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/uuid": "^10.0.0",
+        "@vitest/coverage-v8": "^4.1.9",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.9"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -162,15 +183,6 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@noble/ed25519": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.3.0.tgz",
-      "integrity": "sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -455,17 +467,8 @@
       "license": "MIT"
     },
     "node_modules/@trustagentai/a2a-core": {
-      "version": "0.5.0-alpha.0",
-      "resolved": "file:../trust-agent",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@noble/ed25519": "^2.1.0",
-        "canonicalize": "^2.0.0",
-        "uuid": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
+      "resolved": "../trust-agent",
+      "link": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
@@ -961,15 +964,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/canonicalize": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
-      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "canonicalize": "bin/canonicalize.js"
       }
     },
     "node_modules/chai": {
@@ -2740,20 +2734,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/trust-agent-cloud/src/server.ts
+++ b/trust-agent-cloud/src/server.ts
@@ -15,7 +15,7 @@
 import express from "express";
 import cors from "cors";
 import { loadOrCreateKeyPair } from "@trustagentai/a2a-core";
-import type { IntentEnvelope, AcceptanceReceipt } from "@trustagentai/a2a-core";
+import type { IntentEnvelope, AcceptanceReceipt, SignatureBlock } from "@trustagentai/a2a-core";
 import { initDb, verifyCoSignChain, clearCoSigns } from "./db.js";
 import { CoSignService } from "./witness.js";
 import { initBlobDb, putBlob, getBlob, clearBlobs, type BlobInput } from "./blob-db.js";
@@ -47,15 +47,64 @@ async function main(): Promise<void> {
     res.json({ ok: true, witness_kid: witnessKey.kid })
   );
 
-  app.post("/register-key", (req, res) => {
-    const { kid, publicKeyHex } = req.body as { kid?: string; publicKeyHex?: string };
+  app.post("/register-key", async (req, res) => {
+    const { kid, publicKeyHex, endorsement, timestamp } = req.body as {
+      kid?: string;
+      publicKeyHex?: string;
+      endorsement?: SignatureBlock;
+      /** Required alongside `endorsement` — must be the exact timestamp the
+       *  caller signed into the rotation attestation (verification hashes
+       *  the attestation object, so a server-generated one would never match). */
+      timestamp?: string;
+    };
     if (!kid || !publicKeyHex) {
       res.status(400).json({ error: "kid and publicKeyHex are required" });
       return;
     }
-    service.registerKey(kid, publicKeyHex);
-    console.log(`[trust-agent-cloud] registered peer key: ${kid}`);
-    res.json({ ok: true });
+    if (endorsement && !timestamp) {
+      res.status(400).json({ error: "timestamp is required alongside endorsement" });
+      return;
+    }
+    try {
+      await service.registerKey(kid, publicKeyHex, endorsement, timestamp);
+      console.log(`[trust-agent-cloud] registered peer key: ${kid}`);
+      res.json({ ok: true });
+    } catch (err) {
+      console.warn(`[trust-agent-cloud] key registration refused for ${kid}`, err);
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  // Delta #6: revoke the currently active key for a DID (any of its kids),
+  // and read back its full epoch history (the transparency log).
+  app.post("/revoke-key", async (req, res) => {
+    const { kid, endorsement, timestamp } = req.body as {
+      kid?: string;
+      endorsement?: SignatureBlock;
+      timestamp?: string;
+    };
+    if (!kid || !endorsement || !timestamp) {
+      res.status(400).json({ error: "kid, endorsement, and timestamp are required" });
+      return;
+    }
+    try {
+      await service.revokeKey(kid, endorsement, timestamp);
+      console.log(`[trust-agent-cloud] revoked key: ${kid}`);
+      res.json({ ok: true });
+    } catch (err) {
+      console.warn(`[trust-agent-cloud] key revocation refused for ${kid}`, err);
+      res.status(400).json({ error: String(err) });
+    }
+  });
+
+  app.get("/key-history/:kid", (req, res) => {
+    const history = service.getKeyHistory(req.params.kid).map((e) => ({
+      kid: e.kid,
+      publicKeyHex: Buffer.from(e.publicKey).toString("hex"),
+      validFrom: e.validFrom,
+      validUntil: e.validUntil,
+    }));
+    res.json(history);
   });
 
   app.post("/co-sign", async (req, res) => {

--- a/trust-agent-cloud/src/witness.test.ts
+++ b/trust-agent-cloud/src/witness.test.ts
@@ -8,6 +8,9 @@ import {
   buildIntentEnvelope,
   buildAcceptanceReceipt,
   verifyCoSignReceipt,
+  buildRotationAttestation,
+  signRotation,
+  signEnvelope,
 } from "@trustagentai/a2a-core";
 import type { KeyPair, IntentEnvelope, AcceptanceReceipt } from "@trustagentai/a2a-core";
 import { initDb, clearCoSigns, getCoSignChain, verifyCoSignChain } from "./db.js";
@@ -22,9 +25,9 @@ interface Handshake {
   proxyBKey: KeyPair;
 }
 
-async function makeHandshake(): Promise<Handshake> {
-  const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
-  const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+async function makeHandshake(keys?: { proxyAKey: KeyPair; proxyBKey: KeyPair }): Promise<Handshake> {
+  const proxyAKey = keys?.proxyAKey ?? (await generateKeyPair("did:workload:bank-a-proxy#key-1"));
+  const proxyBKey = keys?.proxyBKey ?? (await generateKeyPair("did:workload:bank-b-proxy#key-1"));
   const { envelope: intent } = await buildIntentEnvelope({
     initiatorDid: "did:workload:bank-a-agent",
     vcRef: "vc:test",
@@ -47,8 +50,8 @@ async function makeHandshake(): Promise<Handshake> {
 async function serviceWith(h: Handshake): Promise<{ svc: CoSignService; witnessKey: KeyPair }> {
   const witnessKey = await generateKeyPair("did:workload:trustagent-cloud#key-1");
   const svc = new CoSignService(witnessKey);
-  svc.registerKey(h.proxyAKey.kid, Buffer.from(h.proxyAKey.publicKey).toString("hex"));
-  svc.registerKey(h.proxyBKey.kid, Buffer.from(h.proxyBKey.publicKey).toString("hex"));
+  await svc.registerKey(h.proxyAKey.kid, Buffer.from(h.proxyAKey.publicKey).toString("hex"));
+  await svc.registerKey(h.proxyBKey.kid, Buffer.from(h.proxyBKey.publicKey).toString("hex"));
   return { svc, witnessKey };
 }
 
@@ -120,16 +123,92 @@ describe("CoSignService.coSign", () => {
     const { svc } = await serviceWith(h1);
     const r1 = await svc.coSign(h1.intent, h1.acceptance);
 
-    // Second transaction: re-register the (same-kid) keys for its proxies.
-    const h2 = await makeHandshake();
-    svc.registerKey(h2.proxyAKey.kid, Buffer.from(h2.proxyAKey.publicKey).toString("hex"));
-    svc.registerKey(h2.proxyBKey.kid, Buffer.from(h2.proxyBKey.publicKey).toString("hex"));
+    // Second transaction: same proxy identities (kid + key), already
+    // registered — a real second transaction doesn't re-register a key.
+    const h2 = await makeHandshake({ proxyAKey: h1.proxyAKey, proxyBKey: h1.proxyBKey });
     const r2 = await svc.coSign(h2.intent, h2.acceptance);
 
     expect(r1.seq).toBe(0);
     expect(r2.seq).toBe(1);
     expect(getCoSignChain()).toHaveLength(2);
     expect(verifyCoSignChain().valid).toBe(true);
+  });
+});
+
+describe("CoSignService key-transparency (Delta #6)", () => {
+  it("accepts an endorsed rotation and co-signs under the new key, not the old", async () => {
+    const witnessKey = await generateKeyPair("did:workload:trustagent-cloud#key-1");
+    const svc = new CoSignService(witnessKey);
+    const did = "did:workload:bank-a-proxy";
+    const oldKey = await generateKeyPair(`${did}#key-1`);
+    await svc.registerKey(oldKey.kid, Buffer.from(oldKey.publicKey).toString("hex"));
+
+    const newKey = await generateKeyPair(`${did}#key-2`);
+    const newPubHex = Buffer.from(newKey.publicKey).toString("hex");
+    const rotatedAt = "2026-02-01T00:00:00.000Z";
+    const attestation = buildRotationAttestation(did, newKey.kid, newPubHex, rotatedAt);
+    const endorsement = await signRotation(attestation, oldKey);
+    await expect(svc.registerKey(newKey.kid, newPubHex, endorsement, rotatedAt)).resolves.toBeUndefined();
+
+    const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+    await svc.registerKey(proxyBKey.kid, Buffer.from(proxyBKey.publicKey).toString("hex"));
+
+    const { envelope: intent } = await buildIntentEnvelope({
+      initiatorDid: "did:workload:bank-a-agent",
+      vcRef: "vc:test",
+      targetDid: "did:workload:bank-b-proxy",
+      mcpDeploymentId: "did:workload:bank-b-proxy",
+      toolName: "execute_wire_transfer",
+      toolSchemaHash: "deadbeef",
+      mcpSessionId: "sess-1",
+      args: { amount: 100 },
+      proxyKey: newKey, // signed with the ROTATED key
+    });
+    const acceptance = await buildAcceptanceReceipt({
+      intentEnvelope: intent,
+      policyEvalInput: { decision: "ACCEPTED" },
+      proxyKey: proxyBKey,
+    });
+
+    await expect(svc.coSign(intent, acceptance)).resolves.toHaveProperty("idempotent", false);
+  });
+
+  it("rejects a rotation with no endorsement, and one endorsed by the wrong key", async () => {
+    const witnessKey = await generateKeyPair("did:workload:trustagent-cloud#key-1");
+    const svc = new CoSignService(witnessKey);
+    const did = "did:workload:bank-a-proxy";
+    const oldKey = await generateKeyPair(`${did}#key-1`);
+    await svc.registerKey(oldKey.kid, Buffer.from(oldKey.publicKey).toString("hex"));
+
+    const newKey = await generateKeyPair(`${did}#key-2`);
+    const newPubHex = Buffer.from(newKey.publicKey).toString("hex");
+
+    await expect(svc.registerKey(newKey.kid, newPubHex)).rejects.toThrow();
+
+    const impostor = await generateKeyPair("impostor");
+    const attestation = buildRotationAttestation(did, newKey.kid, newPubHex, new Date().toISOString());
+    const badEndorsement = await signRotation(attestation, impostor);
+    await expect(svc.registerKey(newKey.kid, newPubHex, badEndorsement)).rejects.toThrow();
+  });
+
+  it("revokes a key, after which it can no longer co-sign for that DID", async () => {
+    const witnessKey = await generateKeyPair("did:workload:trustagent-cloud#key-1");
+    const svc = new CoSignService(witnessKey);
+    const did = "did:workload:bank-a-proxy";
+    const key = await generateKeyPair(`${did}#key-1`);
+    await svc.registerKey(key.kid, Buffer.from(key.publicKey).toString("hex"));
+
+    const revokedAt = "2026-02-01T00:00:00.000Z";
+    const revokeAttestation = { did, revoke_kid: key.kid, timestamp: revokedAt };
+    const revokeEndorsement = await signEnvelope(revokeAttestation, key, "proxy");
+    await expect(svc.revokeKey(key.kid, revokeEndorsement, revokedAt)).resolves.toBeUndefined();
+
+    const history = svc.getKeyHistory(key.kid);
+    expect(history).toHaveLength(1);
+    expect(history[0].validUntil).not.toBeNull();
+    // The kid itself still resolves (past signatures stay verifiable) — only
+    // NEW registrations/rotations for this DID are now blocked without it.
+    await expect(svc.registerKey(`${did}#key-2`, "aa")).rejects.toThrow();
   });
 });
 

--- a/trust-agent-cloud/src/witness.ts
+++ b/trust-agent-cloud/src/witness.ts
@@ -11,10 +11,14 @@
 import {
   verifyHandshake,
   buildCoSignReceipt,
+  KeyRegistry,
+  didFromKid,
+  type KeyEpoch,
   type IntentEnvelope,
   type AcceptanceReceipt,
   type CoSignReceipt,
   type KeyPair,
+  type SignatureBlock,
 } from "@trustagentai/a2a-core";
 import { appendCoSign, getCoSignByTrace } from "./db.js";
 
@@ -26,14 +30,44 @@ export interface CoSignOutcome {
 }
 
 export class CoSignService {
-  /** kid → public key. Populated by each bank registering with the witness. */
-  private readonly keys = new Map<string, Uint8Array>();
+  /** Append-only key-transparency registry (Delta #6). Populated by each
+   *  bank registering (bootstrap) or rotating (endorsed) with the witness. */
+  private readonly registry = new KeyRegistry();
 
   constructor(private readonly witnessKey: KeyPair) {}
 
-  /** Register a proxy's public key so the witness can verify its signatures. */
-  registerKey(kid: string, publicKeyHex: string): void {
-    this.keys.set(kid, Buffer.from(publicKeyHex, "hex"));
+  /**
+   * Register a proxy's public key so the witness can verify its signatures.
+   * The first registration for a DID is trust-on-first-use; any later one
+   * for the same DID is a rotation and requires `endorsement` — a signature
+   * from the DID's prior key over `buildRotationAttestation(did, kid,
+   * publicKeyHex, timestamp)` (see `@trustagentai/a2a-core`'s
+   * `key-registry.ts`). `timestamp` MUST be the exact value the caller
+   * signed the endorsement over — verification hashes the attestation
+   * object, so a regenerated timestamp here would never match. Throws on an
+   * unendorsed or badly-endorsed rotation.
+   */
+  async registerKey(
+    kid: string,
+    publicKeyHex: string,
+    endorsement?: SignatureBlock,
+    timestamp: string = new Date().toISOString()
+  ): Promise<void> {
+    await this.registry.register(didFromKid(kid), kid, publicKeyHex, timestamp, endorsement);
+  }
+
+  /**
+   * Revoke the currently active key for a DID (identified by any of its
+   * kids). `timestamp` must match what the caller signed into
+   * `{ did, revoke_kid, timestamp }` when producing `endorsement`.
+   */
+  async revokeKey(kid: string, endorsement: SignatureBlock, timestamp: string = new Date().toISOString()): Promise<void> {
+    await this.registry.revoke(didFromKid(kid), timestamp, endorsement);
+  }
+
+  /** Full key-epoch history for a DID (identified by any of its kids) — the transparency log. */
+  getKeyHistory(kid: string): readonly KeyEpoch[] {
+    return this.registry.getHistory(didFromKid(kid));
   }
 
   /**
@@ -48,7 +82,7 @@ export class CoSignService {
       return { ...existing, idempotent: true };
     }
 
-    await verifyHandshake(intent, acceptance, (kid) => this.keys.get(kid));
+    await verifyHandshake(intent, acceptance, (kid) => this.registry.resolveByKid(kid));
     const receipt = await buildCoSignReceipt(intent, acceptance, this.witnessKey);
     const { seq, prev_hash } = appendCoSign(intent.trace_id, receipt);
     return { receipt, seq, prev_hash, idempotent: false };

--- a/trust-agent/src/index.ts
+++ b/trust-agent/src/index.ts
@@ -11,3 +11,4 @@ export * from "./risk-budget.js";
 export * from "./trust-proxy.js";
 export * from "./worm.js";
 export * from "./worm-store.js";
+export * from "./key-registry.js";

--- a/trust-agent/src/key-registry.test.ts
+++ b/trust-agent/src/key-registry.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { generateKeyPair, signEnvelope } from "./crypto.js";
+import type { KeyPair, SignatureBlock } from "./crypto.js";
+import { KeyRegistry, buildRotationAttestation, didFromKid } from "./key-registry.js";
+
+const DID = "did:workload:bank-a-proxy";
+
+async function endorse(priorKey: KeyPair, did: string, newKid: string, newPublicKeyHex: string, now: string): Promise<SignatureBlock> {
+  const attestation = buildRotationAttestation(did, newKid, newPublicKeyHex, now);
+  return signEnvelope(attestation as unknown as Record<string, unknown>, priorKey, "proxy");
+}
+
+describe("KeyRegistry.register", () => {
+  it("accepts a first registration for a DID without endorsement (trust-on-first-use)", async () => {
+    const registry = new KeyRegistry();
+    const key = await generateKeyPair(`${DID}#key-1`);
+    await registry.register(DID, key.kid, Buffer.from(key.publicKey).toString("hex"), "2026-01-01T00:00:00.000Z");
+    expect(registry.resolveByKid(key.kid)).toEqual(key.publicKey);
+  });
+
+  it("rejects a second registration for the same DID without an endorsement", async () => {
+    const registry = new KeyRegistry();
+    const key1 = await generateKeyPair(`${DID}#key-1`);
+    await registry.register(DID, key1.kid, Buffer.from(key1.publicKey).toString("hex"), "2026-01-01T00:00:00.000Z");
+
+    const key2 = await generateKeyPair(`${DID}#key-2`);
+    await expect(
+      registry.register(DID, key2.kid, Buffer.from(key2.publicKey).toString("hex"), "2026-02-01T00:00:00.000Z")
+    ).rejects.toThrow();
+  });
+
+  it("accepts a rotation endorsed by the prior key, closing the old epoch", async () => {
+    const registry = new KeyRegistry();
+    const key1 = await generateKeyPair(`${DID}#key-1`);
+    await registry.register(DID, key1.kid, Buffer.from(key1.publicKey).toString("hex"), "2026-01-01T00:00:00.000Z");
+
+    const key2 = await generateKeyPair(`${DID}#key-2`);
+    const pub2Hex = Buffer.from(key2.publicKey).toString("hex");
+    const now = "2026-02-01T00:00:00.000Z";
+    const endorsement = await endorse(key1, DID, key2.kid, pub2Hex, now);
+
+    await registry.register(DID, key2.kid, pub2Hex, now, endorsement);
+
+    expect(registry.resolveByKid(key2.kid)).toEqual(key2.publicKey);
+    expect(registry.resolveByKid(key1.kid)).toEqual(key1.publicKey); // history preserved
+    expect(registry.getHistory(DID).find((e) => e.kid === key1.kid)?.validUntil).toBe(now);
+    expect(registry.getHistory(DID).find((e) => e.kid === key2.kid)?.validUntil).toBeNull();
+  });
+
+  it("rejects a rotation endorsed by the wrong key", async () => {
+    const registry = new KeyRegistry();
+    const key1 = await generateKeyPair(`${DID}#key-1`);
+    await registry.register(DID, key1.kid, Buffer.from(key1.publicKey).toString("hex"), "2026-01-01T00:00:00.000Z");
+
+    const key2 = await generateKeyPair(`${DID}#key-2`);
+    const impostor = await generateKeyPair("impostor");
+    const pub2Hex = Buffer.from(key2.publicKey).toString("hex");
+    const now = "2026-02-01T00:00:00.000Z";
+    const badEndorsement = await endorse(impostor, DID, key2.kid, pub2Hex, now);
+
+    await expect(registry.register(DID, key2.kid, pub2Hex, now, badEndorsement)).rejects.toThrow();
+  });
+
+  it("is idempotent when the same kid is re-registered with the same key", async () => {
+    const registry = new KeyRegistry();
+    const key1 = await generateKeyPair(`${DID}#key-1`);
+    const pubHex = Buffer.from(key1.publicKey).toString("hex");
+    await registry.register(DID, key1.kid, pubHex, "2026-01-01T00:00:00.000Z");
+    await expect(registry.register(DID, key1.kid, pubHex, "2026-01-02T00:00:00.000Z")).resolves.toBeUndefined();
+    expect(registry.getHistory(DID)).toHaveLength(1);
+  });
+
+  it("rejects re-registering an existing kid under a different key", async () => {
+    const registry = new KeyRegistry();
+    const key1 = await generateKeyPair(`${DID}#key-1`);
+    await registry.register(DID, key1.kid, Buffer.from(key1.publicKey).toString("hex"), "2026-01-01T00:00:00.000Z");
+
+    const impostorKey = await generateKeyPair("unused");
+    const impostorHex = Buffer.from(impostorKey.publicKey).toString("hex");
+    await expect(registry.register(DID, key1.kid, impostorHex, "2026-01-02T00:00:00.000Z")).rejects.toThrow();
+  });
+});
+
+describe("didFromKid", () => {
+  it("splits the DID off of a kid string", () => {
+    expect(didFromKid(`${DID}#key-1`)).toBe(DID);
+  });
+});
+
+describe("KeyRegistry.get (Map-compatible alias)", () => {
+  it("behaves like resolveByKid", async () => {
+    const registry = new KeyRegistry();
+    const key = await generateKeyPair(`${DID}#key-1`);
+    await registry.register(DID, key.kid, Buffer.from(key.publicKey).toString("hex"), "2026-01-01T00:00:00.000Z");
+    expect(registry.get(key.kid)).toEqual(key.publicKey);
+    expect(registry.get("unknown")).toBeUndefined();
+  });
+});
+
+describe("KeyRegistry.resolveAt", () => {
+  it("resolves the key that was valid at a given past timestamp, even after rotation", async () => {
+    const registry = new KeyRegistry();
+    const key1 = await generateKeyPair(`${DID}#key-1`);
+    await registry.register(DID, key1.kid, Buffer.from(key1.publicKey).toString("hex"), "2026-01-01T00:00:00.000Z");
+
+    const key2 = await generateKeyPair(`${DID}#key-2`);
+    const pub2Hex = Buffer.from(key2.publicKey).toString("hex");
+    const rotatedAt = "2026-02-01T00:00:00.000Z";
+    const endorsement = await endorse(key1, DID, key2.kid, pub2Hex, rotatedAt);
+    await registry.register(DID, key2.kid, pub2Hex, rotatedAt, endorsement);
+
+    expect(registry.resolveAt(DID, "2026-01-15T00:00:00.000Z")).toEqual(key1.publicKey);
+    expect(registry.resolveAt(DID, "2026-03-01T00:00:00.000Z")).toEqual(key2.publicKey);
+  });
+
+  it("returns undefined for a DID with no registration", () => {
+    expect(new KeyRegistry().resolveAt("did:unknown", "2026-01-01T00:00:00.000Z")).toBeUndefined();
+  });
+});
+
+describe("KeyRegistry.revoke", () => {
+  it("closes the active epoch and resolveAt no longer finds a valid key", async () => {
+    const registry = new KeyRegistry();
+    const key1 = await generateKeyPair(`${DID}#key-1`);
+    const pubHex = Buffer.from(key1.publicKey).toString("hex");
+    await registry.register(DID, key1.kid, pubHex, "2026-01-01T00:00:00.000Z");
+
+    const now = "2026-02-01T00:00:00.000Z";
+    const attestation = { did: DID, revoke_kid: key1.kid, timestamp: now };
+    const endorsement = await signEnvelope(attestation, key1, "proxy");
+    await registry.revoke(DID, now, endorsement);
+
+    expect(registry.resolveAt(DID, "2026-03-01T00:00:00.000Z")).toBeUndefined();
+    expect(registry.resolveByKid(key1.kid)).toEqual(key1.publicKey); // history preserved
+  });
+
+  it("rejects revocation when there is no active key", async () => {
+    const registry = new KeyRegistry();
+    const key1 = await generateKeyPair(`${DID}#key-1`);
+    const attestation = { did: DID, revoke_kid: key1.kid, timestamp: "2026-01-01T00:00:00.000Z" };
+    const endorsement = await signEnvelope(attestation, key1, "proxy");
+    await expect(registry.revoke(DID, "2026-01-01T00:00:00.000Z", endorsement)).rejects.toThrow();
+  });
+});

--- a/trust-agent/src/key-registry.ts
+++ b/trust-agent/src/key-registry.ts
@@ -1,0 +1,145 @@
+/**
+ * TrustAgentAI — Append-only key-transparency registry (Delta #6)
+ *
+ * Replaces the mutable "last write wins" key registration (`Map.set(kid,
+ * pubkey)`) used through Delta #5. A party (DID) may hold at most one
+ * *currently valid* key epoch at a time:
+ *  - The FIRST registration for a DID is trust-on-first-use (no prior key
+ *    exists to vouch for it — same trust assumption `register-peer-key`
+ *    always had).
+ *  - Every SUBSEQUENT registration for that DID is a rotation and MUST be
+ *    endorsed: signed by the party's current (or last-known) key over a
+ *    `RotationAttestation` binding old -> new. This is what closes
+ *    "whose key" repudiation (DISPUTE_HARDENING Decision #10) — an attacker
+ *    without the prior private key cannot hijack someone else's identity.
+ *  - Revocation closes the active epoch's validity window rather than
+ *    deleting it (revocation-as-append): a revoked key's past signatures
+ *    remain verifiable, but it can no longer authorize a further rotation.
+ *
+ * Recovering an identity after its last key is lost/revoked (with no prior
+ * key available to endorse a replacement) is an explicit, out-of-scope
+ * bootstrap problem for this MVP — see docs/execution_plan.md §5 Delta #6.
+ */
+
+import { signEnvelope, verifySignature } from "./crypto.js";
+import type { KeyPair, SignatureBlock } from "./crypto.js";
+
+/** One key's validity window for a given DID. */
+export interface KeyEpoch {
+  kid: string;
+  publicKey: Uint8Array;
+  validFrom: string;
+  validUntil: string | null;
+}
+
+/** What the prior key signs to authorize its own replacement. */
+export interface RotationAttestation {
+  did: string;
+  new_kid: string;
+  new_public_key_hex: string;
+  timestamp: string;
+}
+
+/** A kid is always `did:workload:X#key-N` — the DID is everything before `#`. */
+export function didFromKid(kid: string): string {
+  return kid.split("#")[0];
+}
+
+export function buildRotationAttestation(
+  did: string,
+  newKid: string,
+  newPublicKeyHex: string,
+  timestamp: string
+): RotationAttestation {
+  return { did, new_kid: newKid, new_public_key_hex: newPublicKeyHex, timestamp };
+}
+
+/** Convenience for callers who hold the prior KeyPair directly. */
+export async function signRotation(
+  attestation: RotationAttestation,
+  priorKey: KeyPair
+): Promise<SignatureBlock> {
+  return signEnvelope(attestation as unknown as Record<string, unknown>, priorKey, "proxy");
+}
+
+export class KeyRegistry {
+  private readonly epochsByDid = new Map<string, KeyEpoch[]>();
+  private readonly epochByKid = new Map<string, Uint8Array>();
+
+  /**
+   * Register a new key for `did`. First-ever call for a DID needs no
+   * `endorsement`. Every later call MUST carry a signature (from the DID's
+   * last-known key) over `buildRotationAttestation(did, kid, publicKeyHex, now)` —
+   * verified before the new epoch is accepted.
+   */
+  async register(
+    did: string,
+    kid: string,
+    publicKeyHex: string,
+    now: string,
+    endorsement?: SignatureBlock
+  ): Promise<void> {
+    const publicKey = new Uint8Array(Buffer.from(publicKeyHex, "hex"));
+    const existing = this.epochByKid.get(kid);
+    if (existing) {
+      if (Buffer.from(existing).equals(Buffer.from(publicKey))) return; // idempotent resubmit
+      throw new Error(`kid already registered with a different key: ${kid}`);
+    }
+
+    const epochs = this.epochsByDid.get(did) ?? [];
+    const last = epochs[epochs.length - 1];
+
+    if (last) {
+      if (!endorsement) {
+        throw new Error(`registration for ${did} requires endorsement from the prior key (${last.kid})`);
+      }
+      const attestation = buildRotationAttestation(did, kid, publicKeyHex, now);
+      await verifySignature(attestation as unknown as Record<string, unknown>, endorsement, last.publicKey);
+      if (last.validUntil === null) last.validUntil = now;
+    }
+
+    const epoch: KeyEpoch = { kid, publicKey, validFrom: now, validUntil: null };
+    this.epochsByDid.set(did, [...epochs, epoch]);
+    this.epochByKid.set(kid, publicKey);
+  }
+
+  /**
+   * Close the currently active epoch for `did` without replacing it.
+   * `endorsement` must be signed by that same active key, over
+   * `{ did, revoke_kid, timestamp }` — proving the caller still controls it.
+   */
+  async revoke(did: string, now: string, endorsement: SignatureBlock): Promise<void> {
+    const epochs = this.epochsByDid.get(did) ?? [];
+    const current = epochs.find((e) => e.validUntil === null);
+    if (!current) throw new Error(`no active key to revoke for ${did}`);
+
+    const attestation = { did, revoke_kid: current.kid, timestamp: now };
+    await verifySignature(attestation as unknown as Record<string, unknown>, endorsement, current.publicKey);
+    current.validUntil = now;
+  }
+
+  /** Raw lookup by kid, regardless of current validity (history is kept). */
+  resolveByKid(kid: string): Uint8Array | undefined {
+    return this.epochByKid.get(kid);
+  }
+
+  /** Alias for {@link resolveByKid} — makes KeyRegistry a drop-in for any
+   *  call site that used to hold a plain `Map<string, Uint8Array>`. */
+  get(kid: string): Uint8Array | undefined {
+    return this.resolveByKid(kid);
+  }
+
+  /** The key that was valid for `did` at `timestamp` (or undefined). */
+  resolveAt(did: string, timestamp: string): Uint8Array | undefined {
+    const epochs = this.epochsByDid.get(did) ?? [];
+    const epoch = epochs.find(
+      (e) => e.validFrom <= timestamp && (e.validUntil === null || timestamp < e.validUntil)
+    );
+    return epoch?.publicKey;
+  }
+
+  /** Full epoch history for a DID, oldest first — the transparency log. */
+  getHistory(did: string): readonly KeyEpoch[] {
+    return this.epochsByDid.get(did) ?? [];
+  }
+}

--- a/trust-agent/src/trust-proxy.ts
+++ b/trust-agent/src/trust-proxy.ts
@@ -241,9 +241,15 @@ export class ProxyAGateway {
 
 // ─── Proxy B (Executor Side) ──────────────────────────────────────────────────
 
+/** Anything that resolves a kid to its public key — a plain `Map` or a
+ *  `KeyRegistry` (Delta #6) both satisfy this. */
+export interface PublicKeySource {
+  get(kid: string): Uint8Array | undefined;
+}
+
 export interface ProxyBConfig {
   proxyKey: KeyPair;
-  proxyAPublicKeys: Map<string, Uint8Array>; // kid → publicKey
+  proxyAPublicKeys: PublicKeySource; // kid → publicKey
   nonceRegistry: NonceRegistry;
   budgetEngine: RiskBudgetEngine;
   ledger: DAGLedger;

--- a/trust-agent/vitest.config.ts
+++ b/trust-agent/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],
-      include: ["src/crypto.ts", "src/hash-chain.ts", "src/co-sign.ts", "src/worm.ts", "src/worm-store.ts"],
+      include: ["src/crypto.ts", "src/hash-chain.ts", "src/co-sign.ts", "src/worm.ts", "src/worm-store.ts", "src/key-registry.ts"],
       thresholds: {
         lines: 80,
         functions: 80,


### PR DESCRIPTION
## Summary

Implements Delta #6 from `docs/execution_plan.md` §5 / DISPUTE_HARDENING Decision #10: replaces the mutable, last-write-wins key registration (`Map.set(kid, pubkey)`) with an append-only **key-transparency registry**.

- **`trust-agent/src/key-registry.ts`** — `KeyRegistry`: a DID's first registration is trust-on-first-use; every later one is a **rotation** and requires an **endorsement** — a signature from the DID's *prior* key over the rotation attestation. This closes "whose key" repudiation: an attacker without the prior private key cannot hijack someone else's identity. **Revocation** closes the active epoch's validity window without deleting it (revocation-as-append) — a revoked key's past signatures remain verifiable, it just can't authorize anything new. Re-registering an existing kid with the *identical* key is idempotent (matches this codebase's established idempotent-on-resubmit convention — hash-chain rows, cosigns, WORM blobs all work this way); a *different* key under an existing kid is rejected.
- **`trust-agent/src/trust-proxy.ts`** — widened `ProxyBConfig.proxyAPublicKeys` from `Map<string, Uint8Array>` to a new `PublicKeySource` interface (`{ get(kid) }`), so `KeyRegistry` is a structural drop-in with zero behavior change for existing Map-based tests.
- **Witness (`trust-agent-cloud`)** — `CoSignService` now holds a `KeyRegistry`; `POST /register-key` accepts an optional `{endorsement, timestamp}` for rotation (omitted = unchanged bootstrap behavior); new `POST /revoke-key` and `GET /key-history/:kid` (the transparency log, public keys only).
- **Bank-B** — same wiring on `/register-peer-key`, plus `POST /revoke-peer-key` and `GET /key-history/:kid`.
- `docs/testing/E2E_ANTIGRAVITY_PROMPT.md` — new Part 3e: bootstrap regression check, live endorsed-rotation round-trip, unendorsed/wrong-key rejection, revocation-as-append.

## A real bug this caught

Early on, `CoSignService.registerKey`/`revokeKey` regenerated `now = new Date().toISOString()` internally instead of accepting the caller's exact timestamp — since verification hashes the *attestation object*, a millisecond drift between what the caller signed and what the service reverified against caused sporadic (timing-dependent) signature-mismatch failures. Fixed by requiring the caller to pass the exact `timestamp` it signed; the integration test that exposed this (`chains two distinct transactions...` in `witness.test.ts`, plus the new revoke test) is what caught it — not the unit tests in isolation.

## Tests + coverage (TDD, RED confirmed before each impl)

- `trust-agent`: 61/61 passing. `key-registry.ts` 97%/91%/91%/97% (stmt/branch/func/line).
- `trust-agent-cloud`: 14/14 passing, all ≥94%.
- `trust-agent`, `trust-agent-cloud`, `Bank-A/proxy`, `Bank-B/proxy` all build clean (`tsc`).
- Covers: bootstrap-no-endorsement, endorsed rotation closing the old epoch, rejection with no/wrong-key endorsement, idempotent-resubmit vs. rejected-different-key, `resolveAt` across a rotation boundary, revoke + post-revocation `resolveAt`, revoke-with-no-active-key rejection — plus the full rotation/rejection/revocation path exercised through `CoSignService` itself.

## Residual risks (disclosed, not regressions)

- **No recovery path if a DID's only key is lost/revoked with no prior key available to endorse a replacement.** This is an explicit, out-of-scope bootstrap problem for the MVP (real key-transparency systems typically solve this with a separate root-of-trust/recovery key or off-chain identity proofing — future work).
- **No live "rotate now" operational trigger** is wired into the running proxies/agents — the registry mechanism is built and fully tested, but nothing in the demo flow calls it end-to-end against a proxy's actual signing key. Exercising it requires the manual curl/Node steps in the new E2E Part 3e.
- Bank-A's `key-exchange.ts` is unchanged (still calls the same bootstrap endpoints) — DID is derived from `kid` server-side (`didFromKid`), so no signature changes were needed there.

## Next (Delta #7, not in this PR)

- **Delta #7** — degraded-mode discipline (heartbeat-gap detection, reconciliation window, value/rate cap on degraded transactions). This closes out the full delta backlog in `docs/execution_plan.md`.

## Test plan

- [x] `cd trust-agent && npm run build && npm run test:coverage`
- [x] `cd trust-agent-cloud && npm run build && npm run test:coverage`
- [x] `cd Bank-A/proxy && npm run build`
- [x] `cd Bank-B/proxy && npm run build`
- [ ] Full `docker-compose` E2E run (Part 3e of the updated prompt) — not run in this session; hand off to the E2E harness per `docs/testing/E2E_ANTIGRAVITY_PROMPT.md`.