### PR TITLE
refactor: DRY cleanup — shared blob-store SQL, key-registry kid helpers

### DIFF
--- a/Bank-A/proxy/package-lock.json
+++ b/Bank-A/proxy/package-lock.json
@@ -1,17 +1,16 @@
 {
   "name": "@demo/bank-a-proxy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@demo/bank-a-proxy",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@trustagentai/a2a-core": "file:../../trust-agent",
         "better-sqlite3": "^9.6.0",
         "cors": "^2.8.6",
-        "ethers": "^6.0.0",
         "express": "^4.22.1"
       },
       "devDependencies": {
@@ -24,7 +23,7 @@
     },
     "../../trust-agent": {
       "name": "@trustagentai/a2a-core",
-      "version": "0.5.0-alpha.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^2.1.0",
@@ -32,10 +31,14 @@
         "uuid": "^10.0.0"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.11",
         "@types/node": "^20.0.0",
         "@types/uuid": "^10.0.0",
+        "@vitest/coverage-v8": "^4.1.9",
+        "better-sqlite3": "^9.6.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.9"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -249,36 +252,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-      "license": "MIT"
-    },
-    "node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@trustagentai/a2a-core": {
       "resolved": "../../trust-agent",
       "link": true
@@ -409,12 +382,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "license": "MIT"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -714,49 +681,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/ethers": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
-      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.1",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "22.7.5",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.7.0",
-        "ws": "8.17.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/ethers/node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT"
     },
     "node_modules/expand-template": {
       "version": "2.0.3",
@@ -1463,12 +1387,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD"
-    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "license": "Apache-2.0",
@@ -1535,27 +1453,6 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     }
   }
 }

--- a/Bank-A/proxy/package-lock.json
+++ b/Bank-A/proxy/package-lock.json
@@ -18,7 +18,11 @@
         "@types/cors": "^2.8.19",
         "@types/express": "^4.17.25",
         "@types/node": "^20.19.39",
-        "typescript": "^5.0.0"
+        "@types/supertest": "^6.0.2",
+        "@vitest/coverage-v8": "^4.1.9",
+        "supertest": "^7.2.2",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.9"
       }
     },
     "../../trust-agent": {
@@ -252,9 +256,465 @@
         "node": ">=6"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@trustagentai/a2a-core": {
       "resolved": "../../trust-agent",
       "link": true
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
@@ -273,6 +733,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "dev": true,
@@ -280,6 +751,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/cors": {
       "version": "2.8.19",
@@ -290,6 +768,20 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.25",
@@ -317,6 +809,13 @@
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -372,6 +871,174 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/superagent": {
+      "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.10.tgz",
+      "integrity": "sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "license": "MIT",
@@ -385,6 +1052,42 @@
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -519,9 +1222,42 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "license": "ISC"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -540,6 +1276,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "license": "MIT",
@@ -549,6 +1292,13 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.7",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -595,6 +1345,16 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "license": "MIT",
@@ -615,6 +1375,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dunder-proto": {
@@ -661,6 +1432,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "license": "MIT",
@@ -671,9 +1449,35 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -687,6 +1491,16 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -735,6 +1549,31 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "license": "MIT"
@@ -755,6 +1594,41 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "license": "MIT",
@@ -772,6 +1646,21 @@
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -827,6 +1716,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "license": "MIT",
@@ -837,8 +1736,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
-      "version": "2.0.3",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -846,6 +1763,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -906,6 +1830,351 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -988,6 +2257,25 @@
       "version": "2.0.0",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "license": "MIT"
@@ -1026,6 +2314,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "license": "MIT",
@@ -1053,6 +2355,62 @@
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
     },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
@@ -1153,6 +2511,40 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/safe-buffer": {
@@ -1294,6 +2686,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "funding": [
@@ -1335,12 +2734,36 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -1354,6 +2777,103 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tar-fs": {
@@ -1380,12 +2900,64 @@
         "node": ">=6"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -1448,6 +3020,191 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/Bank-A/proxy/package.json
+++ b/Bank-A/proxy/package.json
@@ -5,7 +5,9 @@
   "main": "dist/src/server.js",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/src/server.js"
+    "start": "node dist/src/server.js",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@trustagentai/a2a-core": "file:../../trust-agent",
@@ -18,6 +20,10 @@
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.25",
     "@types/node": "^20.19.39",
-    "typescript": "^5.0.0"
+    "@types/supertest": "^6.0.2",
+    "@vitest/coverage-v8": "^4.1.9",
+    "supertest": "^7.2.2",
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.9"
   }
 }

--- a/Bank-A/proxy/src/db.test.ts
+++ b/Bank-A/proxy/src/db.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { tmpdir } from "os";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import {
+  initDb,
+  setSseBus,
+  saveEnvelope,
+  getChain,
+  verifyEnvelopeChain,
+  getEnvelopes,
+  saveProvenance,
+  getEnvelopesByTraceId,
+  clearEnvelopes,
+  saveThought,
+  getThoughts,
+} from "./db.js";
+
+function freshDbPath(): string {
+  return join(tmpdir(), `bank-a-db-test-${randomUUID()}.db`);
+}
+
+beforeEach(() => {
+  setSseBus(null);
+});
+
+describe("saveEnvelope / getChain / verifyEnvelopeChain", () => {
+  it("assigns seq 0 and the genesis prev_hash to the first envelope", () => {
+    initDb(freshDbPath());
+    saveEnvelope("id-1", "INTENT", "trace-1", { a: 1 }, "sig-1");
+    const chain = getChain();
+    expect(chain).toHaveLength(1);
+    expect(chain[0].seq).toBe(0);
+    expect(verifyEnvelopeChain().valid).toBe(true);
+  });
+
+  it("chains subsequent envelopes with incrementing seq and a valid chain", () => {
+    initDb(freshDbPath());
+    saveEnvelope("id-1", "INTENT", "trace-1", { a: 1 }, "sig-1");
+    saveEnvelope("id-2", "ACCEPTANCE", "trace-1", { b: 2 }, "sig-2");
+    const chain = getChain();
+    expect(chain.map((c) => c.seq)).toEqual([0, 1]);
+    expect(verifyEnvelopeChain().valid).toBe(true);
+  });
+
+  it("is a no-op on a duplicate id (does not advance the chain)", () => {
+    initDb(freshDbPath());
+    saveEnvelope("id-1", "INTENT", "trace-1", { a: 1 }, "sig-1");
+    saveEnvelope("id-1", "INTENT", "trace-1", { a: 999 }, "sig-1");
+    expect(getChain()).toHaveLength(1);
+  });
+
+  it("broadcasts system-phase only for INTENT envelopes", () => {
+    const bus = { broadcast: vi.fn() };
+    setSseBus(bus);
+    initDb(freshDbPath());
+
+    saveEnvelope("id-1", "ACCEPTANCE", "trace-1", {}, "sig");
+    expect(bus.broadcast).not.toHaveBeenCalled();
+
+    saveEnvelope("id-2", "INTENT", "trace-1", {}, "sig");
+    expect(bus.broadcast).toHaveBeenCalledWith("system-phase", { phase: "RUNNING" });
+  });
+
+  it("does not throw when no sseBus has been set", () => {
+    initDb(freshDbPath());
+    expect(() => saveEnvelope("id-1", "INTENT", "trace-1", {}, "sig")).not.toThrow();
+  });
+});
+
+describe("backfillChain (legacy rows without seq)", () => {
+  it("assigns seq + prev_hash to pre-existing rows lacking them", () => {
+    const path = freshDbPath();
+    initDb(path);
+
+    // Insert a legacy row directly, bypassing saveEnvelope, with seq/prev_hash NULL.
+    const raw = new Database(path);
+    raw
+      .prepare(
+        "INSERT INTO envelopes (id, type, trace_id, raw_payload, signature, created_at, seq, prev_hash) VALUES (?, ?, ?, ?, ?, ?, NULL, NULL)"
+      )
+      .run("legacy-1", "INTENT", "trace-legacy", "{}", "sig", new Date().toISOString());
+    raw.close();
+
+    // Re-run initDb on the same file — CREATE TABLE IF NOT EXISTS is a no-op,
+    // but backfillChain() runs again and should link the legacy row.
+    initDb(path);
+
+    const chain = getChain();
+    expect(chain).toHaveLength(1);
+    expect(chain[0].seq).toBe(0);
+    expect(verifyEnvelopeChain().valid).toBe(true);
+  });
+});
+
+describe("getEnvelopes / getEnvelopesByTraceId", () => {
+  it("returns all envelopes and filters by trace_id", () => {
+    initDb(freshDbPath());
+    saveEnvelope("id-1", "INTENT", "trace-1", {}, "sig");
+    saveEnvelope("id-2", "INTENT", "trace-2", {}, "sig");
+
+    expect(getEnvelopes()).toHaveLength(2);
+    expect(getEnvelopesByTraceId("trace-1")).toHaveLength(1);
+    expect(getEnvelopesByTraceId("nonexistent")).toHaveLength(0);
+  });
+});
+
+describe("saveProvenance", () => {
+  it("inserts a provenance row and ignores a duplicate content_hash", () => {
+    const path = freshDbPath();
+    initDb(path);
+    saveProvenance("hash-1", "trace-1", "sig-1");
+    saveProvenance("hash-1", "trace-2", "sig-2"); // INSERT OR IGNORE — no-op
+
+    const raw = new Database(path);
+    const rows = raw.prepare("SELECT * FROM provenance").all() as any[];
+    raw.close();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].tx_id).toBe("trace-1");
+  });
+});
+
+describe("saveThought / getThoughts", () => {
+  it("persists and retrieves thoughts in insertion order", () => {
+    initDb(freshDbPath());
+    saveThought("bank-a", "first");
+    saveThought("bank-a", "second");
+    const thoughts = getThoughts();
+    expect(thoughts.map((t: any) => t.text)).toEqual(["first", "second"]);
+  });
+});
+
+describe("clearEnvelopes", () => {
+  it("clears envelopes, provenance, and thoughts tables", () => {
+    initDb(freshDbPath());
+    saveEnvelope("id-1", "INTENT", "trace-1", {}, "sig");
+    saveProvenance("hash-1", "trace-1", "sig-1");
+    saveThought("bank-a", "hello");
+
+    clearEnvelopes();
+
+    expect(getEnvelopes()).toHaveLength(0);
+    expect(getThoughts()).toHaveLength(0);
+  });
+});

--- a/Bank-A/proxy/src/db.ts
+++ b/Bank-A/proxy/src/db.ts
@@ -114,10 +114,9 @@ export function saveEnvelope(
   });
   append();
 
-  // Concurrent SSE broadcast
-  sseBus?.broadcast("envelope", { id, type, trace_id: traceId, created_at: now });
-
-  // Phase transition trigger
+  // Phase transition trigger — server.ts broadcasts the "envelope" event
+  // itself at each saveEnvelope call site, so this is the only SSE event
+  // this module emits.
   if (type === "INTENT") {
     sseBus?.broadcast("system-phase", { phase: "RUNNING" });
   }
@@ -159,9 +158,6 @@ export function saveThought(source: string, text: string): void {
   const now = new Date().toISOString();
   db.prepare("INSERT INTO thoughts (source, text, created_at) VALUES (?, ?, ?)")
     .run(source, text, now);
-  
-  // Concurrent SSE broadcast for real-time UI
-  sseBus?.broadcast("thought", { source, text, ts: now });
 }
 
 export function getThoughts(): any[] {

--- a/Bank-A/proxy/src/key-exchange.test.ts
+++ b/Bank-A/proxy/src/key-exchange.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { registerWithProxyB, registerWithWitness } from "./key-exchange.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+function jsonResponse(ok: boolean): Response {
+  return { ok, status: ok ? 200 : 400, json: async () => ({}) } as unknown as Response;
+}
+
+describe("registerWithProxyB", () => {
+  it("resolves on the first successful call to /register-peer-key", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(true));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(registerWithProxyB("http://proxy-b.test", "kid-1", "hex-1")).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://proxy-b.test/register-peer-key",
+      expect.objectContaining({ method: "POST" })
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toEqual({ kid: "kid-1", publicKeyHex: "hex-1" });
+  });
+
+  it("retries after a non-ok response and eventually succeeds", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(false))
+      .mockResolvedValueOnce(jsonResponse(true));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = registerWithProxyB("http://proxy-b.test", "kid-1", "hex-1", 3);
+    await vi.runAllTimersAsync();
+    await expect(result).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries after a thrown fetch error and eventually succeeds", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+      .mockResolvedValueOnce(jsonResponse(true));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = registerWithProxyB("http://proxy-b.test", "kid-1", "hex-1", 3);
+    await vi.runAllTimersAsync();
+    await expect(result).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after exhausting all retries", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async () => jsonResponse(false));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const assertion = expect(
+      registerWithProxyB("http://proxy-b.test", "kid-1", "hex-1", 2)
+    ).rejects.toThrow(/failed to register with Proxy B/);
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("registerWithWitness", () => {
+  it("posts to /register-key and resolves on success", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(true));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(registerWithWitness("http://witness.test", "kid-1", "hex-1")).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://witness.test/register-key",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("throws after exhausting all retries", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async () => jsonResponse(false));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const assertion = expect(
+      registerWithWitness("http://witness.test", "kid-1", "hex-1", 2)
+    ).rejects.toThrow(/failed to register with witness/);
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/Bank-A/proxy/src/key-exchange.ts
+++ b/Bank-A/proxy/src/key-exchange.ts
@@ -1,26 +1,42 @@
-export async function registerWithProxyB(
-  proxyBUrl: string,
+/**
+ * Register this proxy's public key with a peer (Proxy B or the independent
+ * witness) so they can verify our signatures. Best-effort with retries — the
+ * peer may not be up yet when we boot.
+ */
+async function registerWithPeer(
+  peerUrl: string,
+  registerPath: string,
+  label: string,
   kid: string,
   publicKeyHex: string,
-  retries = 25
+  retries: number
 ): Promise<void> {
   for (let i = 0; i < retries; i++) {
     try {
-      const res = await fetch(`${proxyBUrl}/register-peer-key`, {
+      const res = await fetch(`${peerUrl}${registerPath}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ kid, publicKeyHex }),
       });
       if (res.ok) {
-        console.log("[key-exchange] registered with Proxy B successfully");
+        console.log(`[key-exchange] registered with ${label} successfully`);
         return;
       }
     } catch {
-      // Proxy B not ready yet
+      // Peer not ready yet
     }
     await new Promise((r) => setTimeout(r, 1000));
   }
-  throw new Error("[key-exchange] failed to register with Proxy B after max retries");
+  throw new Error(`[key-exchange] failed to register with ${label} after max retries`);
+}
+
+export function registerWithProxyB(
+  proxyBUrl: string,
+  kid: string,
+  publicKeyHex: string,
+  retries = 25
+): Promise<void> {
+  return registerWithPeer(proxyBUrl, "/register-peer-key", "Proxy B", kid, publicKeyHex, retries);
 }
 
 /**
@@ -29,27 +45,11 @@ export async function registerWithProxyB(
  * Best-effort with retries — the witness holds the key registry independently
  * of both banks.
  */
-export async function registerWithWitness(
+export function registerWithWitness(
   witnessUrl: string,
   kid: string,
   publicKeyHex: string,
   retries = 25
 ): Promise<void> {
-  for (let i = 0; i < retries; i++) {
-    try {
-      const res = await fetch(`${witnessUrl}/register-key`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ kid, publicKeyHex }),
-      });
-      if (res.ok) {
-        console.log("[key-exchange] registered with witness successfully");
-        return;
-      }
-    } catch {
-      // Witness not ready yet
-    }
-    await new Promise((r) => setTimeout(r, 1000));
-  }
-  throw new Error("[key-exchange] failed to register with witness after max retries");
+  return registerWithPeer(witnessUrl, "/register-key", "witness", kid, publicKeyHex, retries);
 }

--- a/Bank-A/proxy/src/server-witness.test.ts
+++ b/Bank-A/proxy/src/server-witness.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from "vitest";
+import { tmpdir } from "os";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import request from "supertest";
+import type { Express } from "express";
+import { generateKeyPair, buildAcceptanceReceipt } from "@trustagentai/a2a-core";
+import type { IntentEnvelope } from "@trustagentai/a2a-core";
+import { jsonResponse, installFetch } from "./test-fetch-mock.js";
+
+/**
+ * TRUSTAGENT_URL is read once at server.ts module-load time, so exercising
+ * the witness-configured branches (/reconcile success/failure) requires
+ * resetting the module registry with the env var stubbed BEFORE re-import —
+ * kept in its own file so it never affects server.test.ts's default (no
+ * witness) module instance.
+ */
+const KEK = "d".repeat(64);
+
+let buildServer: typeof import("./server.js").buildServer;
+let saveEnvelope: typeof import("./db.js").saveEnvelope;
+
+beforeAll(async () => {
+  vi.stubEnv("TRUSTAGENT_URL", "http://witness.test");
+  vi.resetModules();
+  ({ buildServer } = await import("./server.js"));
+  ({ saveEnvelope } = await import("./db.js"));
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function freshApp(
+  handlers: Record<string, (opts?: { body?: string }) => Response | Promise<Response>> = {}
+): Promise<Express> {
+  installFetch(handlers, ["/register-peer-key", "/register-key"]);
+  const { app } = await buildServer({
+    dbPath: join(tmpdir(), `bank-a-witness-test-${randomUUID()}.db`),
+    wormDbPath: join(tmpdir(), `bank-a-witness-test-worm-${randomUUID()}.db`),
+    keystorePath: join(tmpdir(), `bank-a-witness-keystore-${randomUUID()}.json`),
+    keystoreKek: KEK,
+  });
+  return app;
+}
+
+describe("POST /reconcile/:traceId (witness configured)", () => {
+  it("404s when intent/acceptance rows are missing", async () => {
+    const app = await freshApp();
+    const res = await request(app).post("/reconcile/nonexistent-trace").expect(404);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it("returns alreadyReconciled when a COSIGN row already exists", async () => {
+    const app = await freshApp();
+    saveEnvelope("t1:intent", "INTENT", "trace-1", {}, "sig");
+    saveEnvelope("t1:acceptance", "ACCEPTANCE", "trace-1", {}, "sig");
+    saveEnvelope("t1:cosign", "COSIGN", "trace-1", {}, "sig");
+
+    const res = await request(app).post("/reconcile/trace-1").expect(200);
+    expect(res.body).toEqual({ ok: true, alreadyReconciled: true });
+  });
+
+  it("co-signs successfully via the witness and persists a COSIGN row", async () => {
+    const app = await freshApp({
+      "/co-sign": async () =>
+        jsonResponse({ cosign_receipt: { envelope_type: "CoSignReceipt", signatures: [{ role: "witness" }] } }),
+    });
+    saveEnvelope("t2:intent", "INTENT", "trace-2", {}, "sig");
+    saveEnvelope("t2:acceptance", "ACCEPTANCE", "trace-2", {}, "sig");
+
+    const res = await request(app).post("/reconcile/trace-2").expect(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.cosign_receipt).toBeDefined();
+  });
+
+  it("502s when the witness declines to co-sign", async () => {
+    const app = await freshApp({
+      "/co-sign": async () => jsonResponse({ error: "invalid handshake" }, false),
+    });
+    saveEnvelope("t3:intent", "INTENT", "trace-3", {}, "sig");
+    saveEnvelope("t3:acceptance", "ACCEPTANCE", "trace-3", {}, "sig");
+
+    const res = await request(app).post("/reconcile/trace-3").expect(502);
+    expect(res.body.error).toBe("invalid handshake");
+  });
+
+  it("502s when the witness is unreachable", async () => {
+    const app = await freshApp({
+      "/co-sign": async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    saveEnvelope("t4:intent", "INTENT", "trace-4", {}, "sig");
+    saveEnvelope("t4:acceptance", "ACCEPTANCE", "trace-4", {}, "sig");
+
+    const res = await request(app).post("/reconcile/trace-4").expect(502);
+    expect(res.body.error).toBeDefined();
+  });
+});
+
+describe("POST /invoke (witness configured)", () => {
+  it("attaches a witness co-sign receipt and broadcasts the COSIGN envelope event", async () => {
+    const app = await freshApp({
+      "/accept": async (opts) => {
+        const body = JSON.parse(opts!.body!) as { intent: IntentEnvelope };
+        const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+        const acceptance = await buildAcceptanceReceipt({
+          intentEnvelope: body.intent,
+          policyEvalInput: { decision: "ACCEPTED" },
+          proxyKey: proxyBKey,
+        });
+        return jsonResponse({ acceptance });
+      },
+      "/co-sign": async (opts) => {
+        const body = JSON.parse(opts!.body!) as { intent: IntentEnvelope };
+        return jsonResponse({
+          cosign_receipt: {
+            envelope_type: "CoSignReceipt",
+            trace_id: body.intent.trace_id,
+            signatures: [{ role: "witness" }],
+          },
+        });
+      },
+      "/executed": async () => jsonResponse({}),
+    });
+
+    const res = await request(app).post("/invoke").send({ tool: "get_document" }).expect(200);
+    expect(res.body.result._a2a.cosign_receipt).toBeDefined();
+
+    const envelopes = (await request(app).get("/envelopes").expect(200)).body;
+    expect(envelopes.some((e: any) => e.type === "COSIGN")).toBe(true);
+  });
+});

--- a/Bank-A/proxy/src/server.test.ts
+++ b/Bank-A/proxy/src/server.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { tmpdir } from "os";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import request from "supertest";
+import type { Express } from "express";
+import { generateKeyPair, buildAcceptanceReceipt } from "@trustagentai/a2a-core";
+import type { IntentEnvelope } from "@trustagentai/a2a-core";
+import { buildServer } from "./server.js";
+import { jsonResponse, installFetch } from "./test-fetch-mock.js";
+
+const KEK = "c".repeat(64);
+
+async function freshApp(
+  handlers: Record<string, (opts?: { body?: string }) => Response | Promise<Response>> = {}
+): Promise<Express> {
+  installFetch(handlers);
+  const { app } = await buildServer({
+    dbPath: join(tmpdir(), `bank-a-server-test-${randomUUID()}.db`),
+    wormDbPath: join(tmpdir(), `bank-a-server-test-worm-${randomUUID()}.db`),
+    keystorePath: join(tmpdir(), `bank-a-server-keystore-${randomUUID()}.json`),
+    keystoreKek: KEK,
+  });
+  return app;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("buildServer content-KEK validation", () => {
+  afterEach(() => {
+    delete process.env.BANK_A_CONTENT_KEK;
+  });
+
+  it("throws when a content KEK env var is not 64 hex characters", async () => {
+    installFetch();
+    process.env.BANK_A_CONTENT_KEK = "not-valid-hex";
+    await expect(
+      buildServer({
+        dbPath: join(tmpdir(), `bank-a-server-test-${randomUUID()}.db`),
+        wormDbPath: join(tmpdir(), `bank-a-server-test-worm-${randomUUID()}.db`),
+        keystorePath: join(tmpdir(), `bank-a-server-keystore-${randomUUID()}.json`),
+        keystoreKek: KEK,
+      })
+    ).rejects.toThrow(/must be 64 hex characters/);
+  });
+});
+
+describe("GET /health", () => {
+  it("reports ok", async () => {
+    const app = await freshApp();
+    const res = await request(app).get("/health").expect(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+});
+
+describe("trigger / reset lifecycle", () => {
+  it("tracks the triggered flag across /trigger, /trigger-status, /trigger-done", async () => {
+    const app = await freshApp();
+    expect((await request(app).get("/trigger-status").expect(200)).body).toEqual({ triggered: false });
+
+    await request(app).post("/trigger").expect(200);
+    expect((await request(app).get("/trigger-status").expect(200)).body).toEqual({ triggered: true });
+
+    await request(app).post("/trigger-done").expect(200);
+    expect((await request(app).get("/trigger-status").expect(200)).body).toEqual({ triggered: false });
+  });
+
+  it("clears envelopes and resets the triggered flag on /reset", async () => {
+    const app = await freshApp();
+    await request(app).post("/trigger").expect(200);
+
+    await request(app).post("/reset").expect(200);
+    expect((await request(app).get("/trigger-status").expect(200)).body).toEqual({ triggered: false });
+    expect((await request(app).get("/envelopes").expect(200)).body).toEqual([]);
+  });
+});
+
+describe("POST /thought", () => {
+  it("persists a thought and returns it via GET /thoughts", async () => {
+    const app = await freshApp();
+    await request(app).post("/thought").send({ source: "bank-a", text: "hello" }).expect(200);
+    const res = await request(app).get("/thoughts").expect(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0]).toMatchObject({ source: "bank-a", text: "hello" });
+  });
+});
+
+describe("GET /verify-chain", () => {
+  it("reports a valid empty chain", async () => {
+    const app = await freshApp();
+    const res = await request(app).get("/verify-chain").expect(200);
+    expect(res.body.valid).toBe(true);
+  });
+});
+
+describe("POST /invoke", () => {
+  it("completes end-to-end with a mocked Proxy B and persists all envelope types", async () => {
+    installFetch({
+      "/accept": async (opts) => {
+        const body = JSON.parse(opts!.body!) as { intent: IntentEnvelope };
+        const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+        const acceptance = await buildAcceptanceReceipt({
+          intentEnvelope: body.intent,
+          policyEvalInput: { decision: "ACCEPTED" },
+          proxyKey: proxyBKey,
+        });
+        return jsonResponse({ acceptance });
+      },
+      "/executed": async () => jsonResponse({}),
+    });
+
+    const { app } = await buildServer({
+      dbPath: join(tmpdir(), `bank-a-server-test-${randomUUID()}.db`),
+      wormDbPath: join(tmpdir(), `bank-a-server-test-worm-${randomUUID()}.db`),
+      keystorePath: join(tmpdir(), `bank-a-server-keystore-${randomUUID()}.json`),
+      keystoreKek: KEK,
+    });
+
+    const res = await request(app)
+      .post("/invoke")
+      .send({ tool: "get_security_report", args: { q: 1 }, cost: 10 })
+      .expect(200);
+
+    expect(res.body.result._a2a.intent_envelope).toBeDefined();
+    expect(res.body.result._a2a.acceptance_receipt).toBeDefined();
+    expect(res.body.result._a2a.execution_envelope).toBeDefined();
+
+    const envelopes = (await request(app).get("/envelopes").expect(200)).body;
+    const types = envelopes.map((e: any) => e.type).sort();
+    expect(types).toEqual(["ACCEPTANCE", "EXECUTION", "INTENT", "PROVENANCE"]);
+  });
+
+  it("re-registers and retries once when Proxy B reports an unknown key", async () => {
+    let acceptCalls = 0;
+    installFetch({
+      "/accept": async (opts) => {
+        acceptCalls++;
+        if (acceptCalls === 1) {
+          return jsonResponse({ error: "Unknown key id: did:workload:bank-a-proxy#key-1" }, false);
+        }
+        const body = JSON.parse(opts!.body!) as { intent: IntentEnvelope };
+        const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+        const acceptance = await buildAcceptanceReceipt({
+          intentEnvelope: body.intent,
+          policyEvalInput: { decision: "ACCEPTED" },
+          proxyKey: proxyBKey,
+        });
+        return jsonResponse({ acceptance });
+      },
+      "/executed": async () => jsonResponse({}),
+      "/register-peer-key": async () => jsonResponse({ ok: true }),
+    });
+
+    const { app } = await buildServer({
+      dbPath: join(tmpdir(), `bank-a-server-test-${randomUUID()}.db`),
+      wormDbPath: join(tmpdir(), `bank-a-server-test-worm-${randomUUID()}.db`),
+      keystorePath: join(tmpdir(), `bank-a-server-keystore-${randomUUID()}.json`),
+      keystoreKek: KEK,
+    });
+
+    const res = await request(app).post("/invoke").send({ tool: "get_document" }).expect(200);
+    expect(acceptCalls).toBe(2);
+    expect(res.body.result._a2a.intent_envelope).toBeDefined();
+  });
+
+  it("returns a 400 mcp error when Proxy B rejects the intent", async () => {
+    const app = await freshApp({
+      "/accept": async () => jsonResponse({ error: "Insufficient daily budget" }, false),
+    });
+    const res = await request(app).post("/invoke").send({ tool: "execute_wire_transfer", cost: 999999 }).expect(400);
+    expect(res.body.error?.message).toBe("Insufficient daily budget");
+  });
+});
+
+describe("GET /degraded-status/:traceId", () => {
+  it("404s when there is no degraded record for the trace", async () => {
+    const app = await freshApp();
+    const res = await request(app).get("/degraded-status/nonexistent").expect(404);
+    expect(res.body.error).toBeDefined();
+  });
+});
+
+describe("POST /reconcile/:traceId", () => {
+  it("400s when no witness is configured", async () => {
+    const app = await freshApp();
+    const res = await request(app).post("/reconcile/some-trace").expect(400);
+    expect(res.body.error).toBe("no witness configured");
+  });
+});
+
+describe("POST /cross-check", () => {
+  it("400s when traceId is missing", async () => {
+    const app = await freshApp();
+    const res = await request(app).post("/cross-check").send({}).expect(400);
+    expect(res.body.error).toBe("traceId required");
+  });
+
+  it("500s when Proxy B is unreachable for the cross-check", async () => {
+    const app = await freshApp({
+      "/envelopes-by-trace/trace-1": async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    const res = await request(app).post("/cross-check").send({ traceId: "trace-1" }).expect(500);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it("500s when Proxy B responds with a non-ok status", async () => {
+    const app = await freshApp({
+      "/envelopes-by-trace/trace-1": async () => jsonResponse({ error: "db down" }, false),
+    });
+    const res = await request(app).post("/cross-check").send({ traceId: "trace-1" }).expect(500);
+    expect(res.body.error).toMatch(/Proxy B returned/);
+  });
+
+  it("reports synced=true when local and remote envelopes and anchor match", async () => {
+    const app = await freshApp({
+      "/envelopes-by-trace/trace-1": async () => jsonResponse([]),
+      "/verify-trace/trace-1": async () => jsonResponse({ ok: true, allValid: true, blockNumber: 42 }),
+    });
+    const res = await request(app).post("/cross-check").send({ traceId: "trace-1" }).expect(200);
+    expect(res.body.synced).toBe(true);
+    expect(res.body.details.some((d: any) => d.type === "MERKLE_ANCHOR" && d.match)).toBe(true);
+  });
+
+  it("verifies the causal chain and reports synced=true when remote mirrors local exactly", async () => {
+    let localTraceId = "";
+    const app = await freshApp({
+      "/accept": async (opts) => {
+        const body = JSON.parse(opts!.body!) as { intent: IntentEnvelope };
+        localTraceId = body.intent.trace_id;
+        const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+        const acceptance = await buildAcceptanceReceipt({
+          intentEnvelope: body.intent,
+          policyEvalInput: { decision: "ACCEPTED" },
+          proxyKey: proxyBKey,
+        });
+        return jsonResponse({ acceptance });
+      },
+      "/executed": async () => jsonResponse({}),
+    });
+
+    await request(app).post("/invoke").send({ tool: "get_document" }).expect(200);
+    const localEnvelopes = (await request(app).get("/envelopes").expect(200)).body as Array<{
+      type: string;
+      raw_payload: string;
+      signature: string;
+    }>;
+
+    installFetch({
+      [`/envelopes-by-trace/${encodeURIComponent(localTraceId)}`]: async () => jsonResponse(localEnvelopes),
+      [`/verify-trace/${encodeURIComponent(localTraceId)}`]: async () => jsonResponse({ ok: true, allValid: true, blockNumber: 1 }),
+    });
+
+    const res = await request(app).post("/cross-check").send({ traceId: localTraceId }).expect(200);
+    expect(res.body.synced).toBe(true);
+    const causal = res.body.details.find((d: any) => d.type === "CAUSAL_CHAIN");
+    expect(causal.match).toBe(true);
+  });
+
+  it("reports a payload mismatch when remote content differs from local", async () => {
+    let localTraceId = "";
+    const app = await freshApp({
+      "/accept": async (opts) => {
+        const body = JSON.parse(opts!.body!) as { intent: IntentEnvelope };
+        localTraceId = body.intent.trace_id;
+        const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+        const acceptance = await buildAcceptanceReceipt({
+          intentEnvelope: body.intent,
+          policyEvalInput: { decision: "ACCEPTED" },
+          proxyKey: proxyBKey,
+        });
+        return jsonResponse({ acceptance });
+      },
+      "/executed": async () => jsonResponse({}),
+    });
+
+    await request(app).post("/invoke").send({ tool: "get_document" }).expect(200);
+
+    installFetch({
+      [`/envelopes-by-trace/${encodeURIComponent(localTraceId)}`]: async () =>
+        jsonResponse([{ type: "INTENT", raw_payload: JSON.stringify({ tampered: true }), signature: "sig" }]),
+      [`/verify-trace/${encodeURIComponent(localTraceId)}`]: async () => jsonResponse({ ok: false, error: "not anchored yet" }),
+    });
+
+    const res = await request(app).post("/cross-check").send({ traceId: localTraceId }).expect(200);
+    expect(res.body.synced).toBe(false);
+    const intentDetail = res.body.details.find((d: any) => d.type === "INTENT");
+    expect(intentDetail.match).toBe(false);
+    expect(intentDetail.reason).toMatch(/Payload mismatch/);
+  });
+});

--- a/Bank-A/proxy/src/server.ts
+++ b/Bank-A/proxy/src/server.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import cors from "cors";
 import { createHash, randomUUID } from "crypto";
+import { fileURLToPath } from "url";
 import {
   loadOrCreateKeyPair,
   ProxyAGateway,
@@ -17,6 +18,7 @@ import {
 } from "@trustagentai/a2a-core";
 import {
   initDb,
+  setSseBus,
   saveEnvelope,
   getEnvelopes,
   saveProvenance,
@@ -69,26 +71,20 @@ function parseContentKek(envVar: string): Buffer | undefined {
   return Buffer.from(value, "hex");
 }
 
-async function main(): Promise<void> {
-  if (!KEYSTORE_KEK) {
-    throw new Error("KEYSTORE_KEK env var is required to load/create the proxy identity keystore");
-  }
-  const proxyKey = await loadOrCreateKeyPair(PROXY_KID, KEYSTORE_PATH, KEYSTORE_KEK);
+export interface ServerConfig {
+  dbPath: string;
+  wormDbPath: string;
+  keystorePath: string;
+  keystoreKek: string;
+}
 
-  try {
-    const BANK_A_DID = "did:workload:bank-a-proxy";
-    await registerWithProxyB(
-      PROXY_B_URL,
-      `${BANK_A_DID}#key-1`,
-      Buffer.from(proxyKey.publicKey).toString("hex")
-    );
-  } catch (e) {
-    console.warn("[key-exchange] registration failed", e);
-  }
+export async function buildServer(config: ServerConfig): Promise<{ app: express.Express }> {
+  const proxyKey = await loadOrCreateKeyPair(PROXY_KID, config.keystorePath, config.keystoreKek);
 
-  initDb(DB_PATH);
-  initWormDb(WORM_DB_PATH);
+  initDb(config.dbPath);
+  initWormDb(config.wormDbPath);
   const sseBus = new SseBus();
+  setSseBus(sseBus);
 
   // Delta #5: WORM content store holders. Bank-A is the plaintext origin, so
   // it builds the encrypted record and wraps the DEK for every cross-held
@@ -155,7 +151,11 @@ async function main(): Promise<void> {
   });
 
   const publicKeyHex = Buffer.from(proxyKey.publicKey).toString("hex");
-  await registerWithProxyB(PROXY_B_URL, PROXY_KID, publicKeyHex);
+  try {
+    await registerWithProxyB(PROXY_B_URL, PROXY_KID, publicKeyHex);
+  } catch (e) {
+    console.warn("[key-exchange] registration failed", e);
+  }
 
   // Delta #3: register our key with the independent witness so it can verify
   // our Intent signature before co-signing (finality gate).
@@ -384,7 +384,7 @@ async function main(): Promise<void> {
     try {
       let mcpResult = await proxyA.forwardToolCall(call, executor);
 
-      if (mcpResult.error && String(mcpResult.error).includes("Unknown key")) {
+      if (mcpResult.error?.message?.includes("Unknown key")) {
         console.log("[bank-a-proxy] key not recognized by Proxy B — re-registering and retrying");
         await registerWithProxyB(PROXY_B_URL, PROXY_KID, publicKeyHex);
         mcpResult = await proxyA.forwardToolCall(call, executor);
@@ -470,10 +470,26 @@ async function main(): Promise<void> {
     }
   });
 
+  return { app };
+}
+
+async function main(): Promise<void> {
+  if (!KEYSTORE_KEK) {
+    throw new Error("KEYSTORE_KEK env var is required to load/create the proxy identity keystore");
+  }
+  const { app } = await buildServer({
+    dbPath: DB_PATH,
+    wormDbPath: WORM_DB_PATH,
+    keystorePath: KEYSTORE_PATH,
+    keystoreKek: KEYSTORE_KEK,
+  });
   app.listen(PORT, () => console.log(`TrustAgentAI Proxy A listening on :${PORT}`));
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+// Only run the server when this file is executed directly (not when imported, e.g. by tests).
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/Bank-A/proxy/src/test-fetch-mock.ts
+++ b/Bank-A/proxy/src/test-fetch-mock.ts
@@ -1,0 +1,30 @@
+import { vi } from "vitest";
+
+export function jsonResponse(body: unknown, ok = true): Response {
+  return { ok, status: ok ? 200 : 400, json: async () => body } as unknown as Response;
+}
+
+/**
+ * Installs a global fetch mock. Each suffix in `defaultOkSuffixes` auto-succeeds
+ * with `{ ok: true }` unless the caller supplies its own handler for that
+ * suffix in `handlers`; everything else is dispatched to `handlers` by URL
+ * suffix match, or throws if unmatched.
+ */
+export function installFetch(
+  handlers: Record<string, (opts?: { body?: string }) => Response | Promise<Response>> = {},
+  defaultOkSuffixes: string[] = ["/register-peer-key"]
+): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, opts?: { body?: string }) => {
+      const u = String(url);
+      for (const suffix of defaultOkSuffixes) {
+        if (u.endsWith(suffix) && !handlers[suffix]) return jsonResponse({ ok: true });
+      }
+      for (const suffix of Object.keys(handlers)) {
+        if (u.endsWith(suffix)) return handlers[suffix](opts);
+      }
+      throw new Error(`unexpected fetch to ${u}`);
+    })
+  );
+}

--- a/Bank-A/proxy/src/worm-db.test.ts
+++ b/Bank-A/proxy/src/worm-db.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { tmpdir } from "os";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import { initWormDb, putContentBlob } from "./worm-db.js";
+
+const validBlob = {
+  ciphertext: "aa",
+  iv: "bb",
+  tag: "cc",
+  wrappedDeks: { "bank-a": { kek_kid: "bank-a-kek", wrapped_dek: "dd" } },
+};
+
+function freshPath(): string {
+  return join(tmpdir(), `bank-a-worm-db-test-${randomUUID()}.db`);
+}
+
+describe("putContentBlob", () => {
+  it("stores a new content-addressed blob (created: true)", () => {
+    initWormDb(freshPath());
+    const result = putContentBlob("hash-1", validBlob);
+    expect(result.created).toBe(true);
+  });
+
+  it("is idempotent on a write-once replay of the same content", () => {
+    initWormDb(freshPath());
+    putContentBlob("hash-1", validBlob);
+    const result = putContentBlob("hash-1", validBlob);
+    expect(result.created).toBe(false);
+  });
+
+  it("throws when the same contentHash is written with different content", () => {
+    initWormDb(freshPath());
+    putContentBlob("hash-1", validBlob);
+    expect(() => putContentBlob("hash-1", { ...validBlob, ciphertext: "different" })).toThrow();
+  });
+});

--- a/Bank-A/proxy/src/worm-db.ts
+++ b/Bank-A/proxy/src/worm-db.ts
@@ -4,91 +4,28 @@
  * Bank-A is the origin of the plaintext (it has `args`/`outputData` directly
  * from the `/invoke` call), so it is the party that builds the encrypted,
  * content-addressed record (see `buildWormRecord` in `@trustagentai/a2a-core`)
- * and is naturally one of the cross-held copies. This module just persists
- * that already-encrypted record locally — never plaintext, never a bare DEK —
- * with the same write-once invariant as the witness's blob store: a repeat
- * put for the same content hash is idempotent if byte-identical, rejected if
- * it differs.
+ * and is naturally one of the cross-held copies. This module persists that
+ * already-encrypted record locally — never plaintext, never a bare DEK —
+ * using the shared write-once CRUD from `@trustagentai/a2a-core`'s
+ * `createBlobStore` (`trust-agent-cloud/src/blob-db.ts` is its twin for the
+ * witness's own copy).
  */
 
 import Database from "better-sqlite3";
+import { initBlobTable, createBlobStore, type BlobStore } from "@trustagentai/a2a-core";
+export type { StoredBlob, BlobInput, PutBlobResult } from "@trustagentai/a2a-core";
 
-let db: Database.Database;
-
-interface WrappedDek {
-  iv: string;
-  ciphertext: string;
-  tag: string;
-}
-
-export interface StoredBlob {
-  contentHash: string;
-  ciphertext: string;
-  iv: string;
-  tag: string;
-  wrappedDeks: Record<string, WrappedDek>;
-}
+const TABLE = "content_blobs";
+let store: BlobStore;
 
 export function initWormDb(path: string): void {
-  db = new Database(path, { timeout: 5000 });
+  const db = new Database(path, { timeout: 5000 });
   db.pragma("journal_mode = WAL");
   db.pragma("busy_timeout = 5000");
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS content_blobs (
-      content_hash TEXT PRIMARY KEY,
-      ciphertext TEXT NOT NULL,
-      iv TEXT NOT NULL,
-      tag TEXT NOT NULL,
-      wrapped_deks TEXT NOT NULL,
-      created_at TEXT NOT NULL
-    );
-  `);
+  initBlobTable(db, TABLE);
+  store = createBlobStore(db, TABLE);
 }
 
-function toStoredBlob(r: any): StoredBlob {
-  return {
-    contentHash: r.content_hash,
-    ciphertext: r.ciphertext,
-    iv: r.iv,
-    tag: r.tag,
-    wrappedDeks: JSON.parse(r.wrapped_deks),
-  };
-}
-
-function serializeContent(b: Pick<StoredBlob, "ciphertext" | "iv" | "tag" | "wrappedDeks">): string {
-  return JSON.stringify({ ciphertext: b.ciphertext, iv: b.iv, tag: b.tag, wrappedDeks: b.wrappedDeks });
-}
-
-export type BlobInput = Pick<StoredBlob, "ciphertext" | "iv" | "tag" | "wrappedDeks">;
-
-export interface PutBlobResult {
-  blob: StoredBlob;
-  created: boolean;
-}
-
-/** Write-once put, identical invariant to the witness's blob-db.ts. */
-export function putContentBlob(contentHash: string, blob: BlobInput): PutBlobResult {
-  const existingRow = db.prepare("SELECT * FROM content_blobs WHERE content_hash = ?").get(contentHash) as any;
-  if (existingRow) {
-    const existing = toStoredBlob(existingRow);
-    if (serializeContent(existing) === serializeContent(blob)) {
-      return { blob: existing, created: false };
-    }
-    throw new Error(`WORM violation: blob ${contentHash} already stored with different content`);
-  }
-
-  db.prepare(
-    "INSERT INTO content_blobs (content_hash, ciphertext, iv, tag, wrapped_deks, created_at) VALUES (?, ?, ?, ?, ?, ?)"
-  ).run(contentHash, blob.ciphertext, blob.iv, blob.tag, JSON.stringify(blob.wrappedDeks), new Date().toISOString());
-
-  return { blob: { contentHash, ...blob }, created: true };
-}
-
-export function getContentBlob(contentHash: string): StoredBlob | undefined {
-  const row = db.prepare("SELECT * FROM content_blobs WHERE content_hash = ?").get(contentHash) as any;
-  return row ? toStoredBlob(row) : undefined;
-}
-
-export function clearContentBlobs(): void {
-  db.exec("DELETE FROM content_blobs");
-}
+export const putContentBlob: BlobStore["putBlob"] = (contentHash, blob) => store.putBlob(contentHash, blob);
+export const getContentBlob: BlobStore["getBlob"] = (contentHash) => store.getBlob(contentHash);
+export const clearContentBlobs: BlobStore["clearBlobs"] = () => store.clearBlobs();

--- a/Bank-A/proxy/src/worm-db.ts
+++ b/Bank-A/proxy/src/worm-db.ts
@@ -13,7 +13,6 @@
 
 import Database from "better-sqlite3";
 import { initBlobTable, createBlobStore, type BlobStore } from "@trustagentai/a2a-core";
-export type { StoredBlob, BlobInput, PutBlobResult } from "@trustagentai/a2a-core";
 
 const TABLE = "content_blobs";
 let store: BlobStore;
@@ -27,5 +26,3 @@ export function initWormDb(path: string): void {
 }
 
 export const putContentBlob: BlobStore["putBlob"] = (contentHash, blob) => store.putBlob(contentHash, blob);
-export const getContentBlob: BlobStore["getBlob"] = (contentHash) => store.getBlob(contentHash);
-export const clearContentBlobs: BlobStore["clearBlobs"] = () => store.clearBlobs();

--- a/Bank-A/proxy/tsconfig.json
+++ b/Bank-A/proxy/tsconfig.json
@@ -11,5 +11,6 @@
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/Bank-A/proxy/vitest.config.ts
+++ b/Bank-A/proxy/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],
-      include: ["src/crypto.ts", "src/hash-chain.ts", "src/co-sign.ts", "src/worm.ts", "src/worm-store.ts", "src/key-registry.ts", "src/degraded-mode.ts", "src/blob-store-sql.ts", "src/envelopes.ts", "src/ledger.ts", "src/nonce-registry.ts", "src/risk-budget.ts", "src/trust-proxy.ts"],
+      include: ["src/db.ts", "src/worm-db.ts", "src/key-exchange.ts", "src/server.ts"],
       thresholds: {
         lines: 80,
         functions: 80,

--- a/Bank-B/proxy/package-lock.json
+++ b/Bank-B/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@demo/bank-b-proxy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@demo/bank-b-proxy",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@trustagentai/a2a-core": "file:../../trust-agent",
         "better-sqlite3": "^9.6.0",
@@ -18,12 +18,16 @@
         "@types/cors": "^2.8.19",
         "@types/express": "^4.17.25",
         "@types/node": "^20.0.0",
-        "typescript": "^5.0.0"
+        "@types/supertest": "^6.0.2",
+        "@vitest/coverage-v8": "^4.1.9",
+        "supertest": "^7.2.2",
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.9"
       }
     },
     "../../trust-agent": {
       "name": "@trustagentai/a2a-core",
-      "version": "0.5.0-alpha.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^2.1.0",
@@ -31,18 +35,478 @@
         "uuid": "^10.0.0"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.11",
         "@types/node": "^20.0.0",
         "@types/uuid": "^10.0.0",
+        "@vitest/coverage-v8": "^4.1.9",
+        "better-sqlite3": "^9.6.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.9"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@trustagentai/a2a-core": {
       "resolved": "../../trust-agent",
       "link": true
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
@@ -65,6 +529,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -75,6 +550,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -84,6 +566,20 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.25",
@@ -115,6 +611,13 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -182,6 +685,174 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/superagent": {
+      "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.10.tgz",
+      "integrity": "sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -199,6 +870,42 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -353,11 +1060,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -380,6 +1120,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -393,6 +1140,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -445,6 +1199,16 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -471,6 +1235,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dunder-proto": {
@@ -529,6 +1304,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -541,11 +1323,37 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -563,6 +1371,16 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -611,6 +1429,31 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -633,6 +1476,41 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -658,6 +1536,21 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -723,6 +1616,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -735,10 +1638,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -746,6 +1665,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -818,6 +1744,351 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -922,6 +2193,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -970,6 +2260,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -1005,6 +2309,62 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
     },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
@@ -1122,6 +2482,40 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/safe-buffer": {
@@ -1285,6 +2679,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -1330,6 +2731,23 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1338,6 +2756,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -1355,6 +2780,103 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tar-fs": {
@@ -1385,6 +2907,50 @@
         "node": ">=6"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1393,6 +2959,14 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -1471,6 +3045,191 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/Bank-B/proxy/package.json
+++ b/Bank-B/proxy/package.json
@@ -5,7 +5,9 @@
   "main": "dist/src/server.js",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/src/server.js"
+    "start": "node dist/src/server.js",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@trustagentai/a2a-core": "file:../../trust-agent",
@@ -18,6 +20,10 @@
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.25",
     "@types/node": "^20.0.0",
-    "typescript": "^5.0.0"
+    "@types/supertest": "^6.0.2",
+    "@vitest/coverage-v8": "^4.1.9",
+    "supertest": "^7.2.2",
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.9"
   }
 }

--- a/Bank-B/proxy/src/db.test.ts
+++ b/Bank-B/proxy/src/db.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { tmpdir } from "os";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import {
+  initDb,
+  setSseBus,
+  saveEnvelope,
+  getChain,
+  verifyEnvelopeChain,
+  getEnvelopes,
+  getEnvelopesByTraceId,
+  getAnchorByTxHash,
+  getAnchorByTraceId,
+  getAnchorLeaves,
+  getDisputePackByTraceId,
+  getAnchors,
+  clearEnvelopes,
+  saveThought,
+  getThoughts,
+} from "./db.js";
+
+function freshDbPath(): string {
+  return join(tmpdir(), `bank-b-db-test-${randomUUID()}.db`);
+}
+
+/** Insert an envelope, an anchor batch, and one anchor_leaf row directly, bypassing saveEnvelope/db.ts writers. */
+function seedAnchoredEnvelope(path: string, envelopeId: string, traceId: string, type = "INTENT") {
+  const raw = new Database(path);
+  const now = new Date().toISOString();
+  raw
+    .prepare(
+      "INSERT INTO envelopes (id, type, trace_id, raw_payload, signature, created_at, seq, prev_hash) VALUES (?, ?, ?, ?, ?, ?, 0, ?)"
+    )
+    .run(envelopeId, type, traceId, JSON.stringify({ trace_id: traceId }), "sig", now, "0".repeat(64));
+  raw
+    .prepare(
+      "INSERT INTO anchors (batch_id, merkle_root, tx_hash, block_number, status, created_at) VALUES (?, ?, ?, ?, ?, ?)"
+    )
+    .run("batch-1", "deadbeef", "cafebabe", 42, "CONFIRMED", now);
+  raw
+    .prepare(
+      "INSERT INTO anchor_leaves (batch_id, leaf_index, envelope_id, leaf_hash, proof_path) VALUES (?, ?, ?, ?, ?)"
+    )
+    .run("batch-1", 0, envelopeId, "leafhash", JSON.stringify([{ sibling: "x", position: "right" }]));
+  raw.close();
+}
+
+beforeEach(() => {
+  setSseBus(null);
+});
+
+describe("saveEnvelope / getChain / verifyEnvelopeChain", () => {
+  it("chains envelopes with incrementing seq and stays valid", () => {
+    initDb(freshDbPath());
+    saveEnvelope("id-1", "INTENT", "trace-1", {}, "sig");
+    saveEnvelope("id-2", "ACCEPTANCE", "trace-1", {}, "sig");
+    expect(getChain().map((c) => c.seq)).toEqual([0, 1]);
+    expect(verifyEnvelopeChain().valid).toBe(true);
+  });
+
+  it("is a no-op on a duplicate id", () => {
+    initDb(freshDbPath());
+    saveEnvelope("id-1", "INTENT", "trace-1", {}, "sig");
+    saveEnvelope("id-1", "INTENT", "trace-1", { changed: true }, "sig");
+    expect(getChain()).toHaveLength(1);
+  });
+
+  it("broadcasts envelope for every type and system-phase only for INTENT", () => {
+    const bus = { broadcast: vi.fn() };
+    setSseBus(bus);
+    initDb(freshDbPath());
+
+    saveEnvelope("id-1", "ACCEPTANCE", "trace-1", {}, "sig");
+    expect(bus.broadcast).toHaveBeenCalledWith("envelope", expect.objectContaining({ type: "ACCEPTANCE" }));
+    expect(bus.broadcast).not.toHaveBeenCalledWith("system-phase", expect.anything());
+
+    saveEnvelope("id-2", "INTENT", "trace-1", {}, "sig");
+    expect(bus.broadcast).toHaveBeenCalledWith("system-phase", { phase: "RUNNING" });
+  });
+});
+
+describe("getEnvelopes / getEnvelopesByTraceId", () => {
+  it("filters by trace_id", () => {
+    initDb(freshDbPath());
+    saveEnvelope("id-1", "INTENT", "trace-1", {}, "sig");
+    saveEnvelope("id-2", "INTENT", "trace-2", {}, "sig");
+    expect(getEnvelopes()).toHaveLength(2);
+    expect(getEnvelopesByTraceId("trace-1")).toHaveLength(1);
+  });
+});
+
+describe("anchor lookups", () => {
+  it("getAnchorByTxHash finds the anchor and getAnchorByTraceId resolves via the envelope join", () => {
+    const path = freshDbPath();
+    initDb(path);
+    seedAnchoredEnvelope(path, "env-1", "trace-1");
+
+    expect(getAnchorByTxHash("cafebabe")).toMatchObject({ batch_id: "batch-1", block_number: 42 });
+    expect(getAnchorByTraceId("trace-1")).toMatchObject({ batch_id: "batch-1" });
+    expect(getAnchorByTraceId("nonexistent")).toBeNull();
+    expect(getAnchorByTxHash("nonexistent")).toBeFalsy();
+  });
+
+  it("getAnchorLeaves returns leaves joined with envelope type/trace_id", () => {
+    const path = freshDbPath();
+    initDb(path);
+    seedAnchoredEnvelope(path, "env-1", "trace-1");
+
+    const leaves = getAnchorLeaves("batch-1");
+    expect(leaves).toHaveLength(1);
+    expect(leaves[0]).toMatchObject({ envelope_id: "env-1", envelope_type: "INTENT", trace_id: "trace-1" });
+  });
+
+  it("getAnchors returns all anchor batches", () => {
+    const path = freshDbPath();
+    initDb(path);
+    seedAnchoredEnvelope(path, "env-1", "trace-1");
+    expect(getAnchors()).toHaveLength(1);
+  });
+});
+
+describe("getDisputePackByTraceId", () => {
+  it("returns records, entries, and inclusion proofs for an anchored trace", () => {
+    const path = freshDbPath();
+    initDb(path);
+    seedAnchoredEnvelope(path, "env-1", "trace-1");
+
+    const pack = getDisputePackByTraceId("trace-1");
+    expect(pack.records).toHaveLength(1);
+    expect(pack.entries).toHaveLength(1);
+    expect(pack.inclusionProofs).toHaveLength(1);
+    expect(pack.inclusionProofs[0].batch.batch_id).toBe("batch-1");
+  });
+
+  it("returns empty results for a trace with no envelopes", () => {
+    initDb(freshDbPath());
+    const pack = getDisputePackByTraceId("unknown-trace");
+    expect(pack.records).toEqual([]);
+    expect(pack.entries).toEqual([]);
+    expect(pack.inclusionProofs).toEqual([]);
+  });
+
+  it("omits inclusion proofs for envelopes that aren't yet anchored", () => {
+    initDb(freshDbPath());
+    saveEnvelope("id-1", "INTENT", "trace-1", {}, "sig");
+    const pack = getDisputePackByTraceId("trace-1");
+    expect(pack.entries).toHaveLength(1);
+    expect(pack.inclusionProofs).toEqual([]);
+  });
+});
+
+describe("clearEnvelopes", () => {
+  it("clears envelopes, anchors, anchor_leaves, and thoughts", () => {
+    const path = freshDbPath();
+    initDb(path);
+    seedAnchoredEnvelope(path, "env-1", "trace-1");
+    saveThought("bank-b", "hello");
+
+    clearEnvelopes();
+
+    expect(getEnvelopes()).toHaveLength(0);
+    expect(getAnchors()).toHaveLength(0);
+    expect(getThoughts()).toHaveLength(0);
+  });
+});
+
+describe("saveThought / getThoughts", () => {
+  it("persists and retrieves thoughts in order", () => {
+    initDb(freshDbPath());
+    saveThought("bank-b", "first");
+    saveThought("bank-b", "second");
+    expect(getThoughts().map((t: any) => t.text)).toEqual(["first", "second"]);
+  });
+});
+
+describe("backfillChain (legacy rows without seq)", () => {
+  it("assigns seq + prev_hash to pre-existing rows lacking them", () => {
+    const path = freshDbPath();
+    initDb(path);
+
+    const raw = new Database(path);
+    raw
+      .prepare(
+        "INSERT INTO envelopes (id, type, trace_id, raw_payload, signature, created_at, seq, prev_hash) VALUES (?, ?, ?, ?, ?, ?, NULL, NULL)"
+      )
+      .run("legacy-1", "INTENT", "trace-legacy", "{}", "sig", new Date().toISOString());
+    raw.close();
+
+    initDb(path);
+
+    const chain = getChain();
+    expect(chain).toHaveLength(1);
+    expect(chain[0].seq).toBe(0);
+    expect(verifyEnvelopeChain().valid).toBe(true);
+  });
+});

--- a/Bank-B/proxy/src/db.ts
+++ b/Bank-B/proxy/src/db.ts
@@ -255,8 +255,6 @@ export function saveThought(source: string, text: string): void {
   const now = new Date().toISOString();
   db.prepare("INSERT INTO thoughts (source, text, created_at) VALUES (?, ?, ?)")
     .run(source, text, now);
-  
-  sseBus?.broadcast("thought", { source, text, ts: now });
 }
 
 export function getThoughts(): any[] {

--- a/Bank-B/proxy/src/key-exchange.test.ts
+++ b/Bank-B/proxy/src/key-exchange.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { registerWithWitness } from "./key-exchange.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+function jsonResponse(ok: boolean): Response {
+  return { ok, status: ok ? 200 : 400, json: async () => ({}) } as unknown as Response;
+}
+
+describe("registerWithWitness", () => {
+  it("resolves on the first successful call to /register-key", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(true));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(registerWithWitness("http://witness.test", "kid-1", "hex-1")).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://witness.test/register-key",
+      expect.objectContaining({ method: "POST" })
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toEqual({ kid: "kid-1", publicKeyHex: "hex-1" });
+  });
+
+  it("retries after a non-ok response and eventually succeeds", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(false))
+      .mockResolvedValueOnce(jsonResponse(true));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = registerWithWitness("http://witness.test", "kid-1", "hex-1", 3);
+    await vi.runAllTimersAsync();
+    await expect(result).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries after a thrown fetch error and eventually succeeds", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+      .mockResolvedValueOnce(jsonResponse(true));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = registerWithWitness("http://witness.test", "kid-1", "hex-1", 3);
+    await vi.runAllTimersAsync();
+    await expect(result).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after exhausting all retries", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async () => jsonResponse(false));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const assertion = expect(
+      registerWithWitness("http://witness.test", "kid-1", "hex-1", 2)
+    ).rejects.toThrow(/failed to register with witness/);
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/Bank-B/proxy/src/server.test.ts
+++ b/Bank-B/proxy/src/server.test.ts
@@ -1,0 +1,446 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { tmpdir } from "os";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import request from "supertest";
+import type { Express } from "express";
+import { generateKeyPair, buildIntentEnvelope } from "@trustagentai/a2a-core";
+import { buildServer } from "./server.js";
+
+const KEK = "e".repeat(64);
+const BANK_A_DID = "did:workload:bank-a-agent";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Seeds a single-leaf anchored batch directly (bypassing the anchor service) so proofValid can be exercised. */
+function seedAnchor(dbPath: string, envelopeId: string, traceId: string) {
+  const leafHash = "a".repeat(64);
+  const raw = new Database(dbPath);
+  const now = new Date().toISOString();
+  raw
+    .prepare(
+      "INSERT INTO envelopes (id, type, trace_id, raw_payload, signature, created_at, seq, prev_hash) VALUES (?, ?, ?, ?, ?, ?, 0, ?)"
+    )
+    .run(envelopeId, "INTENT", traceId, JSON.stringify({ trace_id: traceId }), "sig", now, "0".repeat(64));
+  raw
+    .prepare(
+      "INSERT INTO anchors (batch_id, merkle_root, tx_hash, block_number, status, created_at) VALUES (?, ?, ?, ?, ?, ?)"
+    )
+    .run("batch-1", leafHash, "cafebabe", 42, "CONFIRMED", now);
+  raw
+    .prepare(
+      "INSERT INTO anchor_leaves (batch_id, leaf_index, envelope_id, leaf_hash, proof_path) VALUES (?, ?, ?, ?, ?)"
+    )
+    .run("batch-1", 0, envelopeId, leafHash, JSON.stringify([]));
+  raw.close();
+}
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return { ok, status: ok ? 200 : 400, json: async () => body } as unknown as Response;
+}
+
+/**
+ * Installs a fetch mock. Requests to the Decision Agent
+ * (bank-b-agent:4002/decide) and the anchor service are dispatched to
+ * per-test handlers when provided; otherwise they throw, which server.ts
+ * already handles as "unreachable, fall back to static policy / report error".
+ */
+function installFetch(handlers: Record<string, (opts?: { body?: string }) => Response | Promise<Response>> = {}) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, opts?: { body?: string }) => {
+      const u = String(url);
+      for (const suffix of Object.keys(handlers)) {
+        if (u.endsWith(suffix)) return handlers[suffix](opts);
+      }
+      throw new Error(`unexpected fetch to ${u}`);
+    })
+  );
+}
+
+async function freshApp(
+  handlers: Record<string, (opts?: { body?: string }) => Response | Promise<Response>> = {}
+): Promise<{ app: Express; dbPath: string }> {
+  installFetch(handlers);
+  const dbPath = join(tmpdir(), `bank-b-server-test-${randomUUID()}.db`);
+  const { app } = await buildServer({
+    dbPath,
+    keystorePath: join(tmpdir(), `bank-b-server-keystore-${randomUUID()}.json`),
+    keystoreKek: KEK,
+  });
+  return { app, dbPath };
+}
+
+async function registerProxyAAndBuildIntent(app: Express, overrides: Partial<Parameters<typeof buildIntentEnvelope>[0]> = {}) {
+  const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+  await request(app)
+    .post("/register-peer-key")
+    .send({ kid: proxyAKey.kid, publicKeyHex: Buffer.from(proxyAKey.publicKey).toString("hex") })
+    .expect(200);
+  const { envelope: intent } = await buildIntentEnvelope({
+    initiatorDid: BANK_A_DID,
+    vcRef: "vc:test",
+    targetDid: "did:workload:bank-b-proxy",
+    mcpDeploymentId: "did:workload:bank-b-proxy",
+    toolName: "execute_wire_transfer",
+    toolSchemaHash: "deadbeef",
+    mcpSessionId: "sess-1",
+    args: { amount: 100 },
+    proxyKey: proxyAKey,
+    ...overrides,
+  });
+  return { intent, proxyAKey };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("GET /health", () => {
+  it("reports ok", async () => {
+    const { app } = await freshApp();
+    const res = await request(app).get("/health").expect(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+});
+
+describe("POST /register-peer-key", () => {
+  it("registers a valid key", async () => {
+    const { app } = await freshApp();
+    const key = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const res = await request(app)
+      .post("/register-peer-key")
+      .send({ kid: key.kid, publicKeyHex: Buffer.from(key.publicKey).toString("hex") })
+      .expect(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("400s when required fields are missing", async () => {
+    const { app } = await freshApp();
+    const res = await request(app).post("/register-peer-key").send({}).expect(400);
+    expect(res.body.error).toMatch(/required/);
+  });
+
+  it("400s when endorsement is given without a timestamp", async () => {
+    const { app } = await freshApp();
+    const key = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const res = await request(app)
+      .post("/register-peer-key")
+      .send({
+        kid: key.kid,
+        publicKeyHex: Buffer.from(key.publicKey).toString("hex"),
+        endorsement: { role: "proxy", kid: key.kid, signature: "x" },
+      })
+      .expect(400);
+    expect(res.body.error).toMatch(/timestamp is required/);
+  });
+
+  it("400s when rotating to a new kid with no endorsement", async () => {
+    const { app } = await freshApp();
+    const oldKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    await request(app)
+      .post("/register-peer-key")
+      .send({ kid: oldKey.kid, publicKeyHex: Buffer.from(oldKey.publicKey).toString("hex") })
+      .expect(200);
+
+    const newKey = await generateKeyPair("did:workload:bank-a-proxy#key-2");
+    const res = await request(app)
+      .post("/register-peer-key")
+      .send({ kid: newKey.kid, publicKeyHex: Buffer.from(newKey.publicKey).toString("hex") })
+      .expect(400);
+    expect(res.body.error).toBeDefined();
+  });
+});
+
+describe("POST /revoke-peer-key", () => {
+  it("400s when required fields are missing", async () => {
+    const { app } = await freshApp();
+    const res = await request(app).post("/revoke-peer-key").send({}).expect(400);
+    expect(res.body.error).toMatch(/required/);
+  });
+
+  it("revokes a registered key given a valid self-endorsement", async () => {
+    const { signEnvelope } = await import("@trustagentai/a2a-core");
+    const { app } = await freshApp();
+    const key = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    await request(app)
+      .post("/register-peer-key")
+      .send({ kid: key.kid, publicKeyHex: Buffer.from(key.publicKey).toString("hex") })
+      .expect(200);
+
+    const revokedAt = new Date().toISOString();
+    const endorsement = await signEnvelope(
+      { did: "did:workload:bank-a-proxy", revoke_kid: key.kid, timestamp: revokedAt },
+      key,
+      "proxy"
+    );
+    const res = await request(app)
+      .post("/revoke-peer-key")
+      .send({ kid: key.kid, endorsement, timestamp: revokedAt })
+      .expect(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("400s when the endorsement is invalid", async () => {
+    const { app } = await freshApp();
+    const key = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    await request(app)
+      .post("/register-peer-key")
+      .send({ kid: key.kid, publicKeyHex: Buffer.from(key.publicKey).toString("hex") })
+      .expect(200);
+
+    const res = await request(app)
+      .post("/revoke-peer-key")
+      .send({ kid: key.kid, endorsement: { role: "proxy", kid: key.kid, signature: "bogus" }, timestamp: new Date().toISOString() })
+      .expect(400);
+    expect(res.body.error).toBeDefined();
+  });
+});
+
+describe("GET /key-history/:kid", () => {
+  it("returns the epoch history for a registered kid", async () => {
+    const { app } = await freshApp();
+    const key = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const hex = Buffer.from(key.publicKey).toString("hex");
+    await request(app).post("/register-peer-key").send({ kid: key.kid, publicKeyHex: hex }).expect(200);
+
+    const res = await request(app).get(`/key-history/${key.kid}`).expect(200);
+    expect(res.body[0]).toMatchObject({ kid: key.kid, publicKeyHex: hex });
+  });
+});
+
+describe("POST /thought", () => {
+  it("persists and returns a thought", async () => {
+    const { app } = await freshApp();
+    await request(app).post("/thought").send({ source: "bank-b", text: "hello" }).expect(200);
+    const res = await request(app).get("/thoughts").expect(200);
+    expect(res.body[0]).toMatchObject({ source: "bank-b", text: "hello" });
+  });
+});
+
+describe("GET /envelopes, /anchors, /verify-chain", () => {
+  it("start empty and verify-chain reports a valid empty chain", async () => {
+    const { app } = await freshApp();
+    expect((await request(app).get("/envelopes").expect(200)).body).toEqual([]);
+    expect((await request(app).get("/anchors").expect(200)).body).toEqual([]);
+    expect((await request(app).get("/verify-chain").expect(200)).body.valid).toBe(true);
+  });
+});
+
+describe("POST /flush", () => {
+  it("flushes the in-memory ledger (no pending entries -> null batch)", async () => {
+    const { app } = await freshApp();
+    const res = await request(app).post("/flush").expect(200);
+    expect(res.body).toEqual({ ok: true, batch: null });
+  });
+});
+
+describe("POST /accept and GET /dispute/:id", () => {
+  it("accepts a valid intent within the registered policy and records it on the ledger", async () => {
+    const { app } = await freshApp();
+    const { intent } = await registerProxyAAndBuildIntent(app);
+
+    const res = await request(app).post("/accept").send({ intent, estimated_cost_usd: 10 }).expect(200);
+    expect(res.body.acceptance?.decision).toBe("ACCEPTED");
+
+    const dispute = await request(app).get(`/dispute/${intent.trace_id}`).expect(200);
+    expect(dispute.body.entries.length).toBeGreaterThan(0);
+  });
+
+  it("rejects and persists a denial when the initiator has no registered policy", async () => {
+    const { app } = await freshApp();
+    const { intent } = await registerProxyAAndBuildIntent(app, { initiatorDid: "did:workload:unregistered-agent" });
+
+    const res = await request(app).post("/accept").send({ intent, estimated_cost_usd: 10 }).expect(400);
+    expect(res.body.error).toMatch(/No policy registered/);
+  });
+
+  it("honors a manual rejection from the Decision Agent", async () => {
+    const { app } = await freshApp({
+      "bank-b-agent:4002/decide": async () =>
+        jsonResponse({ decision: "reject", reason: "flagged by risk model", errorCode: "ERR_BUDGET_EXCEEDED" }),
+    });
+    const { intent } = await registerProxyAAndBuildIntent(app);
+
+    const res = await request(app).post("/accept").send({ intent, estimated_cost_usd: 10 }).expect(400);
+    expect(res.body.error).toBe("flagged by risk model");
+    expect(res.body.errorCode).toBe(-32002);
+  });
+
+  it("proceeds normally when the Decision Agent responds ok but does not reject", async () => {
+    const { app } = await freshApp({
+      "bank-b-agent:4002/decide": async () => jsonResponse({ decision: "approve", reason: "" }),
+    });
+    const { intent } = await registerProxyAAndBuildIntent(app);
+
+    const res = await request(app).post("/accept").send({ intent, estimated_cost_usd: 10 }).expect(200);
+    expect(res.body.acceptance?.decision).toBe("ACCEPTED");
+  });
+
+  it("falls back to the in-memory ledger's dispute pack when non-empty", async () => {
+    const { app } = await freshApp();
+    const { intent } = await registerProxyAAndBuildIntent(app);
+    await request(app).post("/accept").send({ intent, estimated_cost_usd: 10 }).expect(200);
+
+    const dispute = await request(app).get(`/dispute/${intent.trace_id}`).expect(200);
+    expect(dispute.body.records.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to the DB-backed dispute pack for an unknown trace", async () => {
+    const { app } = await freshApp();
+    const dispute = await request(app).get("/dispute/unknown-trace").expect(200);
+    expect(dispute.body.entries).toEqual([]);
+  });
+});
+
+describe("POST /reset", () => {
+  it("clears envelopes and re-initializes the ProxyB gateway", async () => {
+    const { app } = await freshApp();
+    const { intent } = await registerProxyAAndBuildIntent(app);
+    await request(app).post("/accept").send({ intent, estimated_cost_usd: 10 }).expect(200);
+
+    await request(app).post("/reset").expect(200);
+    expect((await request(app).get("/envelopes").expect(200)).body).toEqual([]);
+  });
+});
+
+describe("POST /anchor", () => {
+  it("proxies a successful anchor response", async () => {
+    const { app } = await freshApp({ "/anchor": async () => jsonResponse({ status: "success", blockNumber: 1 }) });
+    const res = await request(app).post("/anchor").expect(200);
+    expect(res.body.status).toBe("success");
+  });
+
+  it("500s when the anchor service responds with a non-ok status", async () => {
+    const { app } = await freshApp({ "/anchor": async () => jsonResponse({ error: "boom" }, false) });
+    const res = await request(app).post("/anchor").expect(500);
+    expect(res.body.error).toBe("boom");
+  });
+
+  it("500s when the anchor service is unreachable", async () => {
+    const { app } = await freshApp({
+      "/anchor": async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    const res = await request(app).post("/anchor").expect(500);
+    expect(res.body.error).toBeDefined();
+  });
+});
+
+describe("GET /verify/:txHash and /verify-trace/:traceId", () => {
+  it("verifies inclusion proofs for an anchored batch", async () => {
+    const { app, dbPath } = await freshApp();
+    seedAnchor(dbPath, "env-1", "trace-1");
+
+    const byTx = await request(app).get("/verify/cafebabe").expect(200);
+    expect(byTx.body.allValid).toBe(true);
+    expect(byTx.body.leaves[0].proofValid).toBe(true);
+
+    const byTrace = await request(app).get("/verify-trace/trace-1").expect(200);
+    expect(byTrace.body.allValid).toBe(true);
+    expect(byTrace.body.leaves[0].proofValid).toBe(true);
+  });
+
+  it("strips a 0x prefix from the tx hash before lookup", async () => {
+    const { app, dbPath } = await freshApp();
+    seedAnchor(dbPath, "env-1", "trace-1");
+    const res = await request(app).get("/verify/0xcafebabe").expect(200);
+    expect(res.body.txHash).toBe("0xcafebabe");
+  });
+
+  it("404s when no anchor exists for the tx hash or trace id", async () => {
+    const { app } = await freshApp();
+    expect((await request(app).get("/verify/0xdeadbeef").expect(404)).body.error).toBeDefined();
+    expect((await request(app).get("/verify-trace/nonexistent").expect(404)).body.error).toBeDefined();
+  });
+});
+
+describe("POST /executed", () => {
+  it("dual-signs the execution envelope and persists an EXECUTION record", async () => {
+    const { app } = await freshApp();
+    const { intent } = await registerProxyAAndBuildIntent(app);
+    const acceptRes = await request(app).post("/accept").send({ intent, estimated_cost_usd: 10 }).expect(200);
+
+    const { buildExecutionEnvelope, generateKeyPair: genKey } = await import("@trustagentai/a2a-core");
+    const proxyAKey = await genKey("did:workload:bank-a-proxy#key-1");
+    const execution = await buildExecutionEnvelope({
+      intentEnvelope: intent,
+      acceptanceReceipt: acceptRes.body.acceptance,
+      status: "COMPLETED",
+      outputData: { ok: true },
+      proxyKey: proxyAKey,
+    });
+
+    const res = await request(app).post("/executed").send({ execution }).expect(200);
+    expect(res.body.execution.signatures.length).toBeGreaterThanOrEqual(2);
+
+    const envelopes = (await request(app).get("/envelopes").expect(200)).body;
+    expect(envelopes.some((e: any) => e.type === "EXECUTION")).toBe(true);
+  });
+});
+
+async function seedPendingTrace(app: Express): Promise<string> {
+  const { intent } = await registerProxyAAndBuildIntent(app);
+  const acceptRes = await request(app).post("/accept").send({ intent, estimated_cost_usd: 10 }).expect(200);
+
+  const { buildExecutionEnvelope, generateKeyPair: genKey } = await import("@trustagentai/a2a-core");
+  const proxyAKey = await genKey("did:workload:bank-a-proxy#key-1");
+  const execution = await buildExecutionEnvelope({
+    intentEnvelope: intent,
+    acceptanceReceipt: acceptRes.body.acceptance,
+    status: "COMPLETED",
+    outputData: { ok: true },
+    proxyKey: proxyAKey,
+  });
+  await request(app).post("/executed").send({ execution }).expect(200);
+  return intent.trace_id;
+}
+
+describe("POST /anchor-now", () => {
+  it("no-ops when there are no pending traces", async () => {
+    const { app } = await freshApp();
+    const res = await request(app).post("/anchor-now").expect(200);
+    expect(res.body).toEqual({ ok: true, queued: 0 });
+  });
+
+  it("queues and anchors pending traces from a completed /executed flow", async () => {
+    const { app } = await freshApp({
+      "/anchor": async () => jsonResponse({ status: "success", txHash: "0xabc", blockNumber: 1 }),
+    });
+    await seedPendingTrace(app);
+
+    const res = await request(app).post("/anchor-now").expect(200);
+    expect(res.body.queued).toBe(1);
+    await sleep(20); // runAnchor() finishes in the background after the response is sent
+  });
+
+  it("logs a noop when the anchor service reports nothing pending", async () => {
+    const { app } = await freshApp({ "/anchor": async () => jsonResponse({ status: "noop" }) });
+    await seedPendingTrace(app);
+
+    await request(app).post("/anchor-now").expect(200);
+    await sleep(20);
+  });
+
+  it("broadcasts anchor-failed when the anchor service reports an error", async () => {
+    const { app } = await freshApp({ "/anchor": async () => jsonResponse({ error: "chain congested" }, false) });
+    await seedPendingTrace(app);
+
+    await request(app).post("/anchor-now").expect(200);
+    await sleep(20);
+  });
+
+  it("broadcasts anchor-failed when the anchor service is unreachable", async () => {
+    const { app } = await freshApp({
+      "/anchor": async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    await seedPendingTrace(app);
+
+    await request(app).post("/anchor-now").expect(200);
+    await sleep(20);
+  });
+});

--- a/Bank-B/proxy/src/server.ts
+++ b/Bank-B/proxy/src/server.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import cors from "cors";
 import { createHash } from "crypto";
+import { fileURLToPath } from "url";
 import {
   loadOrCreateKeyPair,
   ProxyBGateway,
@@ -15,9 +16,10 @@ import {
   type SignatureBlock,
   signEnvelope,
 } from "@trustagentai/a2a-core";
-import { 
-  initDb, 
-  saveEnvelope, 
+import {
+  initDb,
+  setSseBus,
+  saveEnvelope,
   getEnvelopes, 
   clearEnvelopes, 
   getEnvelopesByTraceId, 
@@ -89,13 +91,17 @@ function initProxyB(proxyBKey: KeyPair, proxyAPublicKeys: PublicKeySource) {
   });
 }
 
-async function main(): Promise<void> {
-  if (!KEYSTORE_KEK) {
-    throw new Error("KEYSTORE_KEK env var is required to load/create the proxy identity keystore");
-  }
-  const proxyKey = await loadOrCreateKeyPair(PROXY_KID, KEYSTORE_PATH, KEYSTORE_KEK);
-  initDb(DB_PATH);
+export interface ServerConfig {
+  dbPath: string;
+  keystorePath: string;
+  keystoreKek: string;
+}
+
+export async function buildServer(config: ServerConfig): Promise<{ app: express.Express }> {
+  const proxyKey = await loadOrCreateKeyPair(PROXY_KID, config.keystorePath, config.keystoreKek);
+  initDb(config.dbPath);
   const sseBus = new SseBus();
+  setSseBus(sseBus);
 
   const proxyAPublicKeys = new KeyRegistry();
   initProxyB(proxyKey, proxyAPublicKeys);
@@ -454,10 +460,25 @@ async function main(): Promise<void> {
     }
   });
 
+  return { app };
+}
+
+async function main(): Promise<void> {
+  if (!KEYSTORE_KEK) {
+    throw new Error("KEYSTORE_KEK env var is required to load/create the proxy identity keystore");
+  }
+  const { app } = await buildServer({
+    dbPath: DB_PATH,
+    keystorePath: KEYSTORE_PATH,
+    keystoreKek: KEYSTORE_KEK,
+  });
   app.listen(PORT, () => console.log(`TrustAgentAI Proxy B listening on :${PORT}`));
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+// Only run the server when this file is executed directly (not when imported, e.g. by tests).
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/Bank-B/proxy/src/server.ts
+++ b/Bank-B/proxy/src/server.ts
@@ -8,7 +8,6 @@ import {
   NonceRegistry,
   RiskBudgetEngine,
   KeyRegistry,
-  didFromKid,
   type PublicKeySource,
   type IntentEnvelope,
   type ExecutionEnvelope,
@@ -177,7 +176,7 @@ async function main(): Promise<void> {
       return;
     }
     try {
-      await proxyAPublicKeys.register(didFromKid(kid), kid, publicKeyHex, timestamp ?? new Date().toISOString(), endorsement);
+      await proxyAPublicKeys.registerByKid(kid, publicKeyHex, endorsement, timestamp);
       console.log(`[bank-b-proxy] registered peer key: ${kid}`);
       res.json({ ok: true });
     } catch (err) {
@@ -199,7 +198,7 @@ async function main(): Promise<void> {
       return;
     }
     try {
-      await proxyAPublicKeys.revoke(didFromKid(kid), timestamp, endorsement);
+      await proxyAPublicKeys.revokeByKid(kid, endorsement, timestamp);
       console.log(`[bank-b-proxy] revoked key: ${kid}`);
       res.json({ ok: true });
     } catch (err) {
@@ -209,7 +208,7 @@ async function main(): Promise<void> {
   });
 
   app.get("/key-history/:kid", (req, res) => {
-    const history = proxyAPublicKeys.getHistory(didFromKid(req.params.kid)).map((e) => ({
+    const history = proxyAPublicKeys.historyByKid(req.params.kid).map((e) => ({
       kid: e.kid,
       publicKeyHex: Buffer.from(e.publicKey).toString("hex"),
       validFrom: e.validFrom,

--- a/Bank-B/proxy/tsconfig.json
+++ b/Bank-B/proxy/tsconfig.json
@@ -11,5 +11,6 @@
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/Bank-B/proxy/vitest.config.ts
+++ b/Bank-B/proxy/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],
-      include: ["src/crypto.ts", "src/hash-chain.ts", "src/co-sign.ts", "src/worm.ts", "src/worm-store.ts", "src/key-registry.ts", "src/degraded-mode.ts", "src/blob-store-sql.ts", "src/envelopes.ts", "src/ledger.ts", "src/nonce-registry.ts", "src/risk-budget.ts", "src/trust-proxy.ts"],
+      include: ["src/db.ts", "src/key-exchange.ts", "src/server.ts"],
       thresholds: {
         lines: 80,
         functions: 80,

--- a/trust-agent-cloud/package-lock.json
+++ b/trust-agent-cloud/package-lock.json
@@ -18,7 +18,9 @@
         "@types/cors": "^2.8.19",
         "@types/express": "^4.17.25",
         "@types/node": "^20.19.39",
+        "@types/supertest": "^6.0.2",
         "@vitest/coverage-v8": "^4.1.9",
+        "supertest": "^7.2.2",
         "typescript": "^5.0.0",
         "vitest": "^4.1.9"
       }
@@ -187,6 +189,19 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.138.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
@@ -195,6 +210,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -525,6 +550,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -579,6 +611,13 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -644,6 +683,30 @@
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.10.tgz",
+      "integrity": "sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -809,6 +872,13 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -830,6 +900,13 @@
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -984,6 +1061,29 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -1025,6 +1125,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -1077,6 +1184,16 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1103,6 +1220,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dunder-proto": {
@@ -1175,6 +1303,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1270,6 +1414,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1310,6 +1461,41 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -1430,6 +1616,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -2564,6 +2766,90 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/supports-color": {

--- a/trust-agent-cloud/package-lock.json
+++ b/trust-agent-cloud/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trustagentai/trust-agent-cloud",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trustagentai/trust-agent-cloud",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@trustagentai/a2a-core": "file:../trust-agent",
         "better-sqlite3": "^9.6.0",
@@ -25,7 +25,7 @@
     },
     "../trust-agent": {
       "name": "@trustagentai/a2a-core",
-      "version": "0.5.0-alpha.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^2.1.0",
@@ -33,9 +33,11 @@
         "uuid": "^10.0.0"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.11",
         "@types/node": "^20.0.0",
         "@types/uuid": "^10.0.0",
         "@vitest/coverage-v8": "^4.1.9",
+        "better-sqlite3": "^9.6.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.0.0",
         "vitest": "^4.1.9"

--- a/trust-agent-cloud/package.json
+++ b/trust-agent-cloud/package.json
@@ -21,7 +21,9 @@
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.25",
     "@types/node": "^20.19.39",
+    "@types/supertest": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.9",
+    "supertest": "^7.2.2",
     "typescript": "^5.0.0",
     "vitest": "^4.1.9"
   }

--- a/trust-agent-cloud/src/blob-db.ts
+++ b/trust-agent-cloud/src/blob-db.ts
@@ -4,96 +4,27 @@
  * Persists content-addressed, encrypted blobs pushed by the banks: ciphertext
  * plus each holder's wrapped DEK. The witness NEVER receives plaintext or a
  * bare DEK — only what's needed to (a) serve the encrypted blob back to a
- * holder who can unwrap their own DEK, and (b) enforce write-once: a repeat
- * PUT for the same content hash is idempotent if byte-identical, and rejected
- * if the content differs (see `@trustagentai/a2a-core`'s `WormBlobStore` for
- * the same invariant applied in-memory; this is its SQLite-backed twin so the
- * witness's blob store survives restarts like its cosign chain does).
+ * holder who can unwrap their own DEK, and (b) enforce write-once (see
+ * `@trustagentai/a2a-core`'s `createBlobStore` for the shared CRUD/write-once
+ * logic — this file just binds it to the witness's own DB file and table;
+ * `Bank-A/proxy/src/worm-db.ts` is its twin for Bank-A's local copy).
  */
 
 import Database from "better-sqlite3";
+import { initBlobTable, createBlobStore, type BlobStore } from "@trustagentai/a2a-core";
+export type { StoredBlob, BlobInput, PutBlobResult } from "@trustagentai/a2a-core";
 
-let db: Database.Database;
-
-interface WrappedDek {
-  iv: string;
-  ciphertext: string;
-  tag: string;
-}
-
-export interface StoredBlob {
-  contentHash: string;
-  ciphertext: string;
-  iv: string;
-  tag: string;
-  wrappedDeks: Record<string, WrappedDek>;
-}
+const TABLE = "blobs";
+let store: BlobStore;
 
 export function initBlobDb(path: string): void {
-  db = new Database(path, { timeout: 5000 });
+  const db = new Database(path, { timeout: 5000 });
   db.pragma("journal_mode = WAL");
   db.pragma("busy_timeout = 5000");
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS blobs (
-      content_hash TEXT PRIMARY KEY,
-      ciphertext TEXT NOT NULL,
-      iv TEXT NOT NULL,
-      tag TEXT NOT NULL,
-      wrapped_deks TEXT NOT NULL,
-      created_at TEXT NOT NULL
-    );
-  `);
+  initBlobTable(db, TABLE);
+  store = createBlobStore(db, TABLE);
 }
 
-function toStoredBlob(r: any): StoredBlob {
-  return {
-    contentHash: r.content_hash,
-    ciphertext: r.ciphertext,
-    iv: r.iv,
-    tag: r.tag,
-    wrappedDeks: JSON.parse(r.wrapped_deks),
-  };
-}
-
-function serializeContent(b: Pick<StoredBlob, "ciphertext" | "iv" | "tag" | "wrappedDeks">): string {
-  return JSON.stringify({ ciphertext: b.ciphertext, iv: b.iv, tag: b.tag, wrappedDeks: b.wrappedDeks });
-}
-
-export interface PutBlobResult {
-  blob: StoredBlob;
-  created: boolean;
-}
-
-export type BlobInput = Pick<StoredBlob, "ciphertext" | "iv" | "tag" | "wrappedDeks">;
-
-/**
- * Write-once put: a first write for `contentHash` inserts the row; a repeat
- * write with byte-identical ciphertext/iv/tag/wrappedDeks is a no-op; a
- * repeat write with any difference throws (WORM violation).
- */
-export function putBlob(contentHash: string, blob: BlobInput): PutBlobResult {
-  const existingRow = db.prepare("SELECT * FROM blobs WHERE content_hash = ?").get(contentHash) as any;
-  if (existingRow) {
-    const existing = toStoredBlob(existingRow);
-    if (serializeContent(existing) === serializeContent(blob)) {
-      return { blob: existing, created: false };
-    }
-    throw new Error(`WORM violation: blob ${contentHash} already stored with different content`);
-  }
-
-  db.prepare(
-    "INSERT INTO blobs (content_hash, ciphertext, iv, tag, wrapped_deks, created_at) VALUES (?, ?, ?, ?, ?, ?)"
-  ).run(contentHash, blob.ciphertext, blob.iv, blob.tag, JSON.stringify(blob.wrappedDeks), new Date().toISOString());
-
-  return { blob: { contentHash, ...blob }, created: true };
-}
-
-export function getBlob(contentHash: string): StoredBlob | undefined {
-  const row = db.prepare("SELECT * FROM blobs WHERE content_hash = ?").get(contentHash) as any;
-  return row ? toStoredBlob(row) : undefined;
-}
-
-/** Drop all blob rows (demo /reset and tests). */
-export function clearBlobs(): void {
-  db.exec("DELETE FROM blobs");
-}
+export const putBlob: BlobStore["putBlob"] = (contentHash, blob) => store.putBlob(contentHash, blob);
+export const getBlob: BlobStore["getBlob"] = (contentHash) => store.getBlob(contentHash);
+export const clearBlobs: BlobStore["clearBlobs"] = () => store.clearBlobs();

--- a/trust-agent-cloud/src/server.test.ts
+++ b/trust-agent-cloud/src/server.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from "vitest";
+import { tmpdir } from "os";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import request from "supertest";
+import type { Express } from "express";
+import {
+  generateKeyPair,
+  buildIntentEnvelope,
+  buildAcceptanceReceipt,
+  signEnvelope,
+} from "@trustagentai/a2a-core";
+import type { KeyPair } from "@trustagentai/a2a-core";
+import { buildServer } from "./server.js";
+
+const KEK = "b".repeat(64); // 32-byte hex, test-only
+
+async function freshApp(): Promise<{ app: Express; witnessKey: KeyPair }> {
+  const { app, witnessKey } = await buildServer({
+    dbPath: join(tmpdir(), `cloud-server-test-${randomUUID()}.db`),
+    keystorePath: join(tmpdir(), `cloud-server-keystore-${randomUUID()}.json`),
+    keystoreKek: KEK,
+  });
+  return { app, witnessKey };
+}
+
+async function registeredHandshake(app: Express) {
+  const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+  const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+  await request(app)
+    .post("/register-key")
+    .send({ kid: proxyAKey.kid, publicKeyHex: Buffer.from(proxyAKey.publicKey).toString("hex") })
+    .expect(200);
+  await request(app)
+    .post("/register-key")
+    .send({ kid: proxyBKey.kid, publicKeyHex: Buffer.from(proxyBKey.publicKey).toString("hex") })
+    .expect(200);
+
+  const { envelope: intent } = await buildIntentEnvelope({
+    initiatorDid: "did:workload:bank-a-agent",
+    vcRef: "vc:test",
+    targetDid: "did:workload:bank-b-proxy",
+    mcpDeploymentId: "did:workload:bank-b-proxy",
+    toolName: "execute_wire_transfer",
+    toolSchemaHash: "deadbeef",
+    mcpSessionId: "sess-1",
+    args: { amount: 100 },
+    proxyKey: proxyAKey,
+  });
+  const acceptance = await buildAcceptanceReceipt({
+    intentEnvelope: intent,
+    policyEvalInput: { decision: "ACCEPTED" },
+    proxyKey: proxyBKey,
+  });
+  return { intent, acceptance, proxyAKey, proxyBKey };
+}
+
+describe("GET /health", () => {
+  it("reports ok and the witness kid", async () => {
+    const { app, witnessKey } = await freshApp();
+    const res = await request(app).get("/health").expect(200);
+    expect(res.body).toEqual({ ok: true, witness_kid: witnessKey.kid });
+  });
+});
+
+describe("POST /register-key", () => {
+  it("registers a valid peer key", async () => {
+    const { app } = await freshApp();
+    const key = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const res = await request(app)
+      .post("/register-key")
+      .send({ kid: key.kid, publicKeyHex: Buffer.from(key.publicKey).toString("hex") })
+      .expect(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("400s when kid or publicKeyHex is missing", async () => {
+    const { app } = await freshApp();
+    const res = await request(app).post("/register-key").send({ kid: "x" }).expect(400);
+    expect(res.body.error).toMatch(/required/);
+  });
+
+  it("400s when endorsement is given without a timestamp", async () => {
+    const { app } = await freshApp();
+    const key = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const res = await request(app)
+      .post("/register-key")
+      .send({
+        kid: key.kid,
+        publicKeyHex: Buffer.from(key.publicKey).toString("hex"),
+        endorsement: { role: "proxy", kid: key.kid, signature: "x" },
+      })
+      .expect(400);
+    expect(res.body.error).toMatch(/timestamp is required/);
+  });
+
+  it("400s when the service refuses the registration (rotating to a new kid with no endorsement)", async () => {
+    const { app } = await freshApp();
+    const oldKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    await request(app)
+      .post("/register-key")
+      .send({ kid: oldKey.kid, publicKeyHex: Buffer.from(oldKey.publicKey).toString("hex") })
+      .expect(200);
+
+    const newKey = await generateKeyPair("did:workload:bank-a-proxy#key-2");
+    const res = await request(app)
+      .post("/register-key")
+      .send({ kid: newKey.kid, publicKeyHex: Buffer.from(newKey.publicKey).toString("hex") })
+      .expect(400);
+    expect(res.body.error).toBeDefined();
+  });
+});
+
+describe("POST /revoke-key", () => {
+  it("400s when required fields are missing", async () => {
+    const { app } = await freshApp();
+    const res = await request(app).post("/revoke-key").send({}).expect(400);
+    expect(res.body.error).toMatch(/required/);
+  });
+
+  it("revokes a registered key given a valid self-endorsement", async () => {
+    const { app } = await freshApp();
+    const key = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    await request(app)
+      .post("/register-key")
+      .send({ kid: key.kid, publicKeyHex: Buffer.from(key.publicKey).toString("hex") })
+      .expect(200);
+
+    const revokedAt = new Date().toISOString();
+    const revokeAttestation = { did: "did:workload:bank-a-proxy", revoke_kid: key.kid, timestamp: revokedAt };
+    const endorsement = await signEnvelope(revokeAttestation, key, "proxy");
+
+    const res = await request(app)
+      .post("/revoke-key")
+      .send({ kid: key.kid, endorsement, timestamp: revokedAt })
+      .expect(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("400s when the endorsement is invalid", async () => {
+    const { app } = await freshApp();
+    const key = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    await request(app)
+      .post("/register-key")
+      .send({ kid: key.kid, publicKeyHex: Buffer.from(key.publicKey).toString("hex") })
+      .expect(200);
+
+    const res = await request(app)
+      .post("/revoke-key")
+      .send({ kid: key.kid, endorsement: { role: "proxy", kid: key.kid, signature: "bogus" }, timestamp: new Date().toISOString() })
+      .expect(400);
+    expect(res.body.error).toBeDefined();
+  });
+});
+
+describe("GET /key-history/:kid", () => {
+  it("returns the rotation/revocation epoch history for a kid", async () => {
+    const { app } = await freshApp();
+    const key = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const hex = Buffer.from(key.publicKey).toString("hex");
+    await request(app).post("/register-key").send({ kid: key.kid, publicKeyHex: hex }).expect(200);
+
+    const res = await request(app).get(`/key-history/${key.kid}`).expect(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0]).toMatchObject({ kid: key.kid, publicKeyHex: hex });
+  });
+});
+
+describe("POST /co-sign", () => {
+  it("400s when intent or acceptance is missing", async () => {
+    const { app } = await freshApp();
+    const res = await request(app).post("/co-sign").send({}).expect(400);
+    expect(res.body.error).toMatch(/required/);
+  });
+
+  it("co-signs a valid registered handshake", async () => {
+    const { app } = await freshApp();
+    const { intent, acceptance } = await registeredHandshake(app);
+
+    const res = await request(app).post("/co-sign").send({ intent, acceptance }).expect(200);
+    expect(res.body.cosign_receipt).toBeDefined();
+    expect(res.body.seq).toBe(0);
+    expect(res.body.idempotent).toBe(false);
+  });
+
+  it("400s when the handshake signatures don't verify", async () => {
+    const { app } = await freshApp();
+    const { intent, acceptance } = await registeredHandshake(app);
+    const tampered = { ...intent, payload: { ...intent.payload, args_hash: "0".repeat(64) } };
+
+    const res = await request(app).post("/co-sign").send({ intent: tampered, acceptance }).expect(400);
+    expect(res.body.error).toBeDefined();
+  });
+});
+
+describe("GET /verify-chain", () => {
+  it("reports a valid empty chain, then stays valid after a co-sign", async () => {
+    const { app } = await freshApp();
+    expect((await request(app).get("/verify-chain").expect(200)).body.valid).toBe(true);
+
+    const { intent, acceptance } = await registeredHandshake(app);
+    await request(app).post("/co-sign").send({ intent, acceptance }).expect(200);
+
+    expect((await request(app).get("/verify-chain").expect(200)).body.valid).toBe(true);
+  });
+});
+
+describe("PUT/GET /blob/:contentHash", () => {
+  const validBlob = {
+    ciphertext: "aa",
+    iv: "bb",
+    tag: "cc",
+    wrappedDeks: { "bank-a": { kek_kid: "bank-a-kek", wrapped_dek: "dd" } },
+  };
+
+  it("400s when required blob fields are missing", async () => {
+    const { app } = await freshApp();
+    const res = await request(app).put("/blob/hash1").send({ ciphertext: "aa" }).expect(400);
+    expect(res.body.error).toMatch(/required/);
+  });
+
+  it("stores a new blob (201) and reads it back", async () => {
+    const { app } = await freshApp();
+    const putRes = await request(app).put("/blob/hash1").send(validBlob).expect(201);
+    expect(putRes.body).toEqual({ ok: true, created: true });
+
+    const getRes = await request(app).get("/blob/hash1").expect(200);
+    expect(getRes.body).toMatchObject(validBlob);
+  });
+
+  it("returns 200 (not created) on a write-once idempotent replay", async () => {
+    const { app } = await freshApp();
+    await request(app).put("/blob/hash1").send(validBlob).expect(201);
+    const res = await request(app).put("/blob/hash1").send(validBlob).expect(200);
+    expect(res.body).toEqual({ ok: true, created: false });
+  });
+
+  it("409s when the same contentHash is written with different content", async () => {
+    const { app } = await freshApp();
+    await request(app).put("/blob/hash1").send(validBlob).expect(201);
+    const res = await request(app)
+      .put("/blob/hash1")
+      .send({ ...validBlob, ciphertext: "different" })
+      .expect(409);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it("404s when the blob does not exist", async () => {
+    const { app } = await freshApp();
+    const res = await request(app).get("/blob/does-not-exist").expect(404);
+    expect(res.body.error).toBe("blob not found");
+  });
+});
+
+describe("POST /reset", () => {
+  it("clears the co-sign chain and blob store", async () => {
+    const { app } = await freshApp();
+    const { intent, acceptance } = await registeredHandshake(app);
+    await request(app).post("/co-sign").send({ intent, acceptance }).expect(200);
+    await request(app)
+      .put("/blob/hash1")
+      .send({ ciphertext: "aa", iv: "bb", tag: "cc", wrappedDeks: { a: { kek_kid: "k", wrapped_dek: "d" } } })
+      .expect(201);
+
+    await request(app).post("/reset").expect(200);
+
+    await request(app).get("/blob/hash1").expect(404);
+    expect((await request(app).get("/verify-chain").expect(200)).body.valid).toBe(true);
+  });
+});

--- a/trust-agent-cloud/src/server.ts
+++ b/trust-agent-cloud/src/server.ts
@@ -14,8 +14,9 @@
 
 import express from "express";
 import cors from "cors";
+import { fileURLToPath } from "url";
 import { loadOrCreateKeyPair } from "@trustagentai/a2a-core";
-import type { IntentEnvelope, AcceptanceReceipt, SignatureBlock } from "@trustagentai/a2a-core";
+import type { IntentEnvelope, AcceptanceReceipt, SignatureBlock, KeyPair } from "@trustagentai/a2a-core";
 import { initDb, verifyCoSignChain, clearCoSigns } from "./db.js";
 import { CoSignService } from "./witness.js";
 import { initBlobDb, putBlob, getBlob, clearBlobs, type BlobInput } from "./blob-db.js";
@@ -26,13 +27,17 @@ const KEYSTORE_PATH = process.env.KEYSTORE_PATH ?? "/data/trust-agent-cloud-keys
 const KEYSTORE_KEK = process.env.KEYSTORE_KEK;
 const WITNESS_KID = "did:workload:trustagent-cloud#key-1";
 
-async function main(): Promise<void> {
-  if (!KEYSTORE_KEK) {
-    throw new Error("KEYSTORE_KEK env var is required to load/create the witness identity keystore");
-  }
-  const witnessKey = await loadOrCreateKeyPair(WITNESS_KID, KEYSTORE_PATH, KEYSTORE_KEK);
-  initDb(DB_PATH);
-  initBlobDb(DB_PATH);
+export interface ServerConfig {
+  dbPath: string;
+  keystorePath: string;
+  keystoreKek: string;
+}
+
+/** Builds the Express app and wires all routes, without binding to a port. */
+export async function buildServer(config: ServerConfig): Promise<{ app: express.Express; witnessKey: KeyPair }> {
+  const witnessKey = await loadOrCreateKeyPair(WITNESS_KID, config.keystorePath, config.keystoreKek);
+  initDb(config.dbPath);
+  initBlobDb(config.dbPath);
   const service = new CoSignService(witnessKey);
 
   const app = express();
@@ -164,12 +169,27 @@ async function main(): Promise<void> {
     res.json({ ok: true });
   });
 
+  return { app, witnessKey };
+}
+
+async function main(): Promise<void> {
+  if (!KEYSTORE_KEK) {
+    throw new Error("KEYSTORE_KEK env var is required to load/create the witness identity keystore");
+  }
+  const { app, witnessKey } = await buildServer({
+    dbPath: DB_PATH,
+    keystorePath: KEYSTORE_PATH,
+    keystoreKek: KEYSTORE_KEK,
+  });
   app.listen(PORT, () =>
     console.log(`TrustAgentAI Cloud witness listening on :${PORT} (kid=${witnessKey.kid})`)
   );
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+// Only run the server when this file is executed directly (not when imported, e.g. by tests).
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/trust-agent-cloud/src/witness.ts
+++ b/trust-agent-cloud/src/witness.ts
@@ -12,7 +12,6 @@ import {
   verifyHandshake,
   buildCoSignReceipt,
   KeyRegistry,
-  didFromKid,
   type KeyEpoch,
   type IntentEnvelope,
   type AcceptanceReceipt,
@@ -47,13 +46,13 @@ export class CoSignService {
    * object, so a regenerated timestamp here would never match. Throws on an
    * unendorsed or badly-endorsed rotation.
    */
-  async registerKey(
+  registerKey(
     kid: string,
     publicKeyHex: string,
     endorsement?: SignatureBlock,
     timestamp: string = new Date().toISOString()
   ): Promise<void> {
-    await this.registry.register(didFromKid(kid), kid, publicKeyHex, timestamp, endorsement);
+    return this.registry.registerByKid(kid, publicKeyHex, endorsement, timestamp);
   }
 
   /**
@@ -61,13 +60,13 @@ export class CoSignService {
    * kids). `timestamp` must match what the caller signed into
    * `{ did, revoke_kid, timestamp }` when producing `endorsement`.
    */
-  async revokeKey(kid: string, endorsement: SignatureBlock, timestamp: string = new Date().toISOString()): Promise<void> {
-    await this.registry.revoke(didFromKid(kid), timestamp, endorsement);
+  revokeKey(kid: string, endorsement: SignatureBlock, timestamp: string = new Date().toISOString()): Promise<void> {
+    return this.registry.revokeByKid(kid, endorsement, timestamp);
   }
 
   /** Full key-epoch history for a DID (identified by any of its kids) — the transparency log. */
   getKeyHistory(kid: string): readonly KeyEpoch[] {
-    return this.registry.getHistory(didFromKid(kid));
+    return this.registry.historyByKid(kid);
   }
 
   /**

--- a/trust-agent-cloud/vitest.config.ts
+++ b/trust-agent-cloud/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],
-      include: ["src/db.ts", "src/witness.ts", "src/blob-db.ts"],
+      include: ["src/db.ts", "src/witness.ts", "src/blob-db.ts", "src/server.ts"],
       thresholds: {
         lines: 80,
         functions: 80,

--- a/trust-agent/package-lock.json
+++ b/trust-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trustagentai/a2a-core",
-  "version": "0.5.0-alpha.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trustagentai/a2a-core",
-      "version": "0.5.0-alpha.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^2.1.0",
@@ -14,9 +14,11 @@
         "uuid": "^10.0.0"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.11",
         "@types/node": "^20.0.0",
         "@types/uuid": "^10.0.0",
         "@vitest/coverage-v8": "^4.1.9",
+        "better-sqlite3": "^9.6.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.0.0",
         "vitest": "^4.1.9"
@@ -508,6 +510,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -760,6 +772,86 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/canonicalize": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
@@ -779,6 +871,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -792,6 +891,32 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -813,6 +938,16 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
@@ -828,6 +963,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/expect-type": {
@@ -858,6 +1003,20 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -872,6 +1031,13 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -889,6 +1055,41 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -1242,6 +1443,36 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
@@ -1261,6 +1492,26 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
@@ -1273,6 +1524,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/pathe": {
@@ -1331,6 +1592,76 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
@@ -1365,6 +1696,27 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.4"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -1384,6 +1736,53 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1409,6 +1808,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -1420,6 +1839,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tinybench": {
@@ -1518,6 +1967,19 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1536,6 +1998,13 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1744,6 +2213,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/trust-agent/package.json
+++ b/trust-agent/package.json
@@ -83,9 +83,11 @@
     "uuid": "^10.0.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.11",
     "@types/node": "^20.0.0",
     "@types/uuid": "^10.0.0",
     "@vitest/coverage-v8": "^4.1.9",
+    "better-sqlite3": "^9.6.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.0.0",
     "vitest": "^4.1.9"

--- a/trust-agent/src/blob-store-sql.test.ts
+++ b/trust-agent/src/blob-store-sql.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import { initBlobTable, createBlobStore } from "./blob-store-sql.js";
+
+const sampleBlob = {
+  ciphertext: "aa",
+  iv: "bb",
+  tag: "cc",
+  wrappedDeks: { witness: { iv: "1", ciphertext: "2", tag: "3" } },
+};
+
+function freshStore(tableName = "blobs") {
+  const db = new Database(":memory:");
+  initBlobTable(db, tableName);
+  return createBlobStore(db, tableName);
+}
+
+describe("createBlobStore (shared WORM blob CRUD)", () => {
+  it("stores a new blob and reports it as created", () => {
+    const store = freshStore();
+    const { blob, created } = store.putBlob("hash-1", sampleBlob);
+    expect(created).toBe(true);
+    expect(blob.contentHash).toBe("hash-1");
+    expect(store.getBlob("hash-1")).toEqual(blob);
+  });
+
+  it("is idempotent when the same id is re-put with identical content", () => {
+    const store = freshStore();
+    store.putBlob("hash-1", sampleBlob);
+    const { created } = store.putBlob("hash-1", sampleBlob);
+    expect(created).toBe(false);
+  });
+
+  it("rejects a re-put of the same id with different content", () => {
+    const store = freshStore();
+    store.putBlob("hash-1", sampleBlob);
+    expect(() => store.putBlob("hash-1", { ...sampleBlob, ciphertext: "different" })).toThrow();
+  });
+
+  it("returns undefined for a content hash that was never stored", () => {
+    expect(freshStore().getBlob("missing")).toBeUndefined();
+  });
+
+  it("clearBlobs empties the table", () => {
+    const store = freshStore();
+    store.putBlob("hash-1", sampleBlob);
+    store.clearBlobs();
+    expect(store.getBlob("hash-1")).toBeUndefined();
+  });
+
+  it("works against a custom table name, independently of other tables", () => {
+    const db = new Database(":memory:");
+    initBlobTable(db, "blobs");
+    initBlobTable(db, "content_blobs");
+    const witnessStore = createBlobStore(db, "blobs");
+    const bankStore = createBlobStore(db, "content_blobs");
+
+    witnessStore.putBlob("hash-1", sampleBlob);
+    expect(bankStore.getBlob("hash-1")).toBeUndefined(); // separate tables, no cross-talk
+  });
+});

--- a/trust-agent/src/blob-store-sql.ts
+++ b/trust-agent/src/blob-store-sql.ts
@@ -1,0 +1,123 @@
+/**
+ * TrustAgentAI — shared WORM blob-store SQL (DRY refactor)
+ *
+ * The witness's blob store (Delta #5, `trust-agent-cloud/src/blob-db.ts`) and
+ * Bank-A's local content store (`Bank-A/proxy/src/worm-db.ts`) persisted
+ * byte-for-byte the same write-once CRUD logic against their own SQLite
+ * table. This module is that logic, factored out once. It takes a minimal
+ * structural `SqlDatabase` interface (not the `better-sqlite3` package
+ * itself) so `@trustagentai/a2a-core` stays storage-agnostic — each service
+ * still owns its own `Database` instance, file path, and table name.
+ */
+
+import type { WrappedKey } from "./worm.js";
+
+/** The minimal subset of `better-sqlite3`'s API this module needs. */
+export interface SqlDatabase {
+  exec(sql: string): unknown;
+  prepare(sql: string): {
+    get(...params: unknown[]): any;
+    run(...params: unknown[]): unknown;
+  };
+}
+
+export interface StoredBlob {
+  contentHash: string;
+  ciphertext: string;
+  iv: string;
+  tag: string;
+  wrappedDeks: Record<string, WrappedKey>;
+}
+
+export type BlobInput = Pick<StoredBlob, "ciphertext" | "iv" | "tag" | "wrappedDeks">;
+
+export interface PutBlobResult {
+  blob: StoredBlob;
+  created: boolean;
+}
+
+const TABLE_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+function assertValidTableName(tableName: string): void {
+  if (!TABLE_NAME_PATTERN.test(tableName)) {
+    throw new Error(`invalid table name: ${tableName}`);
+  }
+}
+
+/** Create the WORM blobs table (idempotent) under `tableName`. */
+export function initBlobTable(db: SqlDatabase, tableName: string): void {
+  assertValidTableName(tableName);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS ${tableName} (
+      content_hash TEXT PRIMARY KEY,
+      ciphertext TEXT NOT NULL,
+      iv TEXT NOT NULL,
+      tag TEXT NOT NULL,
+      wrapped_deks TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+  `);
+}
+
+function toStoredBlob(r: any): StoredBlob {
+  return {
+    contentHash: r.content_hash,
+    ciphertext: r.ciphertext,
+    iv: r.iv,
+    tag: r.tag,
+    wrappedDeks: JSON.parse(r.wrapped_deks),
+  };
+}
+
+function serializeContent(b: Pick<StoredBlob, "ciphertext" | "iv" | "tag" | "wrappedDeks">): string {
+  return JSON.stringify({ ciphertext: b.ciphertext, iv: b.iv, tag: b.tag, wrappedDeks: b.wrappedDeks });
+}
+
+export interface BlobStore {
+  /**
+   * Write-once put: a first write for `contentHash` inserts the row; a
+   * repeat write with byte-identical content is a no-op; a repeat write
+   * with any difference throws (WORM violation).
+   */
+  putBlob(contentHash: string, blob: BlobInput): PutBlobResult;
+  getBlob(contentHash: string): StoredBlob | undefined;
+  /** Drop all rows (demo /reset and tests). */
+  clearBlobs(): void;
+}
+
+/**
+ * Bind the write-once WORM blob CRUD to one table on a given SQL connection.
+ * Used identically by the witness's blob store and each proxy's local
+ * content store — only the physical DB file and table name differ.
+ */
+export function createBlobStore(db: SqlDatabase, tableName: string): BlobStore {
+  assertValidTableName(tableName);
+
+  return {
+    putBlob(contentHash: string, blob: BlobInput): PutBlobResult {
+      const existingRow = db.prepare(`SELECT * FROM ${tableName} WHERE content_hash = ?`).get(contentHash);
+      if (existingRow) {
+        const existing = toStoredBlob(existingRow);
+        if (serializeContent(existing) === serializeContent(blob)) {
+          return { blob: existing, created: false };
+        }
+        throw new Error(`WORM violation: blob ${contentHash} already stored with different content`);
+      }
+
+      db.prepare(
+        `INSERT INTO ${tableName} (content_hash, ciphertext, iv, tag, wrapped_deks, created_at) VALUES (?, ?, ?, ?, ?, ?)`
+      ).run(contentHash, blob.ciphertext, blob.iv, blob.tag, JSON.stringify(blob.wrappedDeks), new Date().toISOString());
+
+      return { blob: { contentHash, ...blob }, created: true };
+    },
+
+    getBlob(contentHash: string): StoredBlob | undefined {
+      const row = db.prepare(`SELECT * FROM ${tableName} WHERE content_hash = ?`).get(contentHash);
+      return row ? toStoredBlob(row) : undefined;
+    },
+
+    clearBlobs(): void {
+      db.exec(`DELETE FROM ${tableName}`);
+    },
+  };
+}

--- a/trust-agent/src/envelopes.test.ts
+++ b/trust-agent/src/envelopes.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from "vitest";
+import { generateKeyPair } from "./crypto.js";
+import { verifySignature, sha256Json } from "./crypto.js";
+import {
+  buildIntentEnvelope,
+  buildAcceptanceReceipt,
+  buildExecutionEnvelope,
+  buildContentProvenanceReceipt,
+} from "./envelopes.js";
+
+async function makeIntent(overrides: Partial<Parameters<typeof buildIntentEnvelope>[0]> = {}) {
+  const proxyKey = await generateKeyPair("did:workload:proxy#key-1");
+  return buildIntentEnvelope({
+    initiatorDid: "did:workload:agent#key-1",
+    vcRef: "urn:vc:1",
+    targetDid: "did:workload:bank-b#key-1",
+    mcpDeploymentId: "deploy-1",
+    toolName: "transfer",
+    toolSchemaHash: sha256Json({ schema: "transfer-v1" }),
+    mcpSessionId: "session-1",
+    args: { amount: 10 },
+    proxyKey,
+    ...overrides,
+  });
+}
+
+describe("buildIntentEnvelope", () => {
+  it("builds an envelope with a proxy signature and a matching trace_id", async () => {
+    const { envelope, traceId } = await makeIntent();
+    expect(envelope.envelope_type).toBe("IntentEnvelope");
+    expect(envelope.trace_id).toBe(traceId);
+    expect(envelope.signatures).toHaveLength(1);
+    expect(envelope.signatures[0].role).toBe("proxy");
+  });
+
+  it("hashes args instead of storing them in plaintext", async () => {
+    const { envelope } = await makeIntent({ args: { amount: 10 } });
+    expect(envelope.payload.args_hash).toBe(sha256Json({ amount: 10 }));
+    expect(JSON.stringify(envelope)).not.toContain("amount");
+  });
+
+  it("defaults ttl to 30s when not provided", async () => {
+    const { envelope } = await makeIntent();
+    const ttlMs = new Date(envelope.expires_at).getTime() - new Date(envelope.timestamp).getTime();
+    expect(ttlMs).toBe(30_000);
+  });
+
+  it("honors a custom ttlSeconds", async () => {
+    const { envelope } = await makeIntent({ ttlSeconds: 60 });
+    const ttlMs = new Date(envelope.expires_at).getTime() - new Date(envelope.timestamp).getTime();
+    expect(ttlMs).toBe(60_000);
+  });
+
+  it("adds a second agent signature for Dual-Sign when agentKey is provided", async () => {
+    const agentKey = await generateKeyPair("did:workload:agent#key-1");
+    const { envelope } = await makeIntent({ agentKey });
+    expect(envelope.signatures).toHaveLength(2);
+    expect(envelope.signatures[0].role).toBe("proxy");
+    expect(envelope.signatures[1].role).toBe("agent");
+  });
+
+  it("produces a proxy signature verifiable against the proxy's public key", async () => {
+    const proxyKey = await generateKeyPair("did:workload:proxy#key-1");
+    const { envelope } = await makeIntent({ proxyKey });
+    const { signatures, ...rest } = envelope;
+    await expect(
+      verifySignature(rest as Record<string, unknown>, signatures[0], proxyKey.publicKey)
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("buildAcceptanceReceipt", () => {
+  it("binds intent_hash to the given intent envelope and defaults to ACCEPTED", async () => {
+    const { envelope: intentEnvelope } = await makeIntent();
+    const proxyKey = await generateKeyPair("did:workload:proxy#key-1");
+    const receipt = await buildAcceptanceReceipt({
+      intentEnvelope,
+      policyEvalInput: { risk: "low" },
+      proxyKey,
+    });
+    expect(receipt.trace_id).toBe(intentEnvelope.trace_id);
+    expect(receipt.decision).toBe("ACCEPTED");
+    expect(receipt.signatures).toHaveLength(1);
+  });
+
+  it("honors an explicit REJECTED decision", async () => {
+    const { envelope: intentEnvelope } = await makeIntent();
+    const proxyKey = await generateKeyPair("did:workload:proxy#key-1");
+    const receipt = await buildAcceptanceReceipt({
+      intentEnvelope,
+      policyEvalInput: { risk: "high" },
+      proxyKey,
+      decision: "REJECTED",
+    });
+    expect(receipt.decision).toBe("REJECTED");
+  });
+});
+
+describe("buildExecutionEnvelope", () => {
+  it("binds intent_hash and acceptance_hash and hashes outputData", async () => {
+    const { envelope: intentEnvelope } = await makeIntent();
+    const proxyKey = await generateKeyPair("did:workload:proxy#key-1");
+    const acceptanceReceipt = await buildAcceptanceReceipt({
+      intentEnvelope,
+      policyEvalInput: { risk: "low" },
+      proxyKey,
+    });
+
+    const execution = await buildExecutionEnvelope({
+      intentEnvelope,
+      acceptanceReceipt,
+      status: "COMPLETED",
+      outputData: { result: "ok" },
+      proxyKey,
+    });
+
+    expect(execution.trace_id).toBe(intentEnvelope.trace_id);
+    expect(execution.status).toBe("COMPLETED");
+    expect(execution.result.output_hash).toBe(sha256Json({ result: "ok" }));
+    expect(execution.signatures).toHaveLength(1);
+  });
+
+  it("leaves signatures empty when no proxyKey is provided (Proxy B is the exclusive signer)", async () => {
+    const { envelope: intentEnvelope } = await makeIntent();
+    const proxyKey = await generateKeyPair("did:workload:proxy#key-1");
+    const acceptanceReceipt = await buildAcceptanceReceipt({
+      intentEnvelope,
+      policyEvalInput: { risk: "low" },
+      proxyKey,
+    });
+
+    const execution = await buildExecutionEnvelope({
+      intentEnvelope,
+      acceptanceReceipt,
+      status: "FAILED",
+      outputData: null,
+    });
+
+    expect(execution.status).toBe("FAILED");
+    expect(execution.signatures).toEqual([]);
+  });
+});
+
+describe("buildContentProvenanceReceipt", () => {
+  it("binds execution/intent/acceptance/output hashes and content metadata", async () => {
+    const { envelope: intentEnvelope } = await makeIntent();
+    const proxyKey = await generateKeyPair("did:workload:proxy#key-1");
+    const acceptanceReceipt = await buildAcceptanceReceipt({
+      intentEnvelope,
+      policyEvalInput: { risk: "low" },
+      proxyKey,
+    });
+    const executionEnvelope = await buildExecutionEnvelope({
+      intentEnvelope,
+      acceptanceReceipt,
+      status: "COMPLETED",
+      outputData: { text: "generated content" },
+      proxyKey,
+    });
+
+    const receipt = await buildContentProvenanceReceipt({
+      executionEnvelope,
+      content_type: "text",
+      content_hash: sha256Json("generated content"),
+      content_size_bytes: 18,
+      model_id: "claude",
+      proxyKey,
+    });
+
+    expect(receipt.trace_id).toBe(executionEnvelope.trace_id);
+    expect(receipt.intent_hash).toBe(executionEnvelope.intent_hash);
+    expect(receipt.acceptance_hash).toBe(executionEnvelope.acceptance_hash);
+    expect(receipt.output_hash).toBe(executionEnvelope.result.output_hash);
+    expect(receipt.content.content_type).toBe("text");
+    expect(receipt.content.content_size_bytes).toBe(18);
+    expect(receipt.context?.model_id).toBe("claude");
+    expect(receipt.signatures).toHaveLength(1);
+  });
+
+  it("omits the context field entirely when no optional context is provided", async () => {
+    const { envelope: intentEnvelope } = await makeIntent();
+    const proxyKey = await generateKeyPair("did:workload:proxy#key-1");
+    const acceptanceReceipt = await buildAcceptanceReceipt({
+      intentEnvelope,
+      policyEvalInput: { risk: "low" },
+      proxyKey,
+    });
+    const executionEnvelope = await buildExecutionEnvelope({
+      intentEnvelope,
+      acceptanceReceipt,
+      status: "COMPLETED",
+      outputData: { text: "x" },
+      proxyKey,
+    });
+
+    const receipt = await buildContentProvenanceReceipt({
+      executionEnvelope,
+      content_type: "text",
+      content_hash: sha256Json("x"),
+      proxyKey,
+    });
+
+    expect(receipt.context).toBeUndefined();
+    expect(receipt.content.content_size_bytes).toBeUndefined();
+  });
+});

--- a/trust-agent/src/index.ts
+++ b/trust-agent/src/index.ts
@@ -13,3 +13,4 @@ export * from "./worm.js";
 export * from "./worm-store.js";
 export * from "./key-registry.js";
 export * from "./degraded-mode.js";
+export * from "./blob-store-sql.js";

--- a/trust-agent/src/key-registry.test.ts
+++ b/trust-agent/src/key-registry.test.ts
@@ -142,3 +142,33 @@ describe("KeyRegistry.revoke", () => {
     await expect(registry.revoke(DID, "2026-01-01T00:00:00.000Z", endorsement)).rejects.toThrow();
   });
 });
+
+describe("KeyRegistry *ByKid convenience methods (DRY: kid -> did derivation)", () => {
+  it("registerByKid derives the DID from the kid and registers exactly like register()", async () => {
+    const registry = new KeyRegistry();
+    const key = await generateKeyPair(`${DID}#key-1`);
+    await registry.registerByKid(key.kid, Buffer.from(key.publicKey).toString("hex"), undefined, "2026-01-01T00:00:00.000Z");
+    expect(registry.resolveByKid(key.kid)).toEqual(key.publicKey);
+    expect(registry.historyByKid(key.kid)).toHaveLength(1);
+  });
+
+  it("revokeByKid derives the DID from the kid and revokes exactly like revoke()", async () => {
+    const registry = new KeyRegistry();
+    const key = await generateKeyPair(`${DID}#key-1`);
+    const pubHex = Buffer.from(key.publicKey).toString("hex");
+    await registry.registerByKid(key.kid, pubHex, undefined, "2026-01-01T00:00:00.000Z");
+
+    const now = "2026-02-01T00:00:00.000Z";
+    const endorsement = await signEnvelope({ did: DID, revoke_kid: key.kid, timestamp: now }, key, "proxy");
+    await registry.revokeByKid(key.kid, endorsement, now);
+
+    expect(registry.resolveAt(DID, "2026-03-01T00:00:00.000Z")).toBeUndefined();
+  });
+
+  it("historyByKid returns the same history as getHistory(didFromKid(kid))", async () => {
+    const registry = new KeyRegistry();
+    const key = await generateKeyPair(`${DID}#key-1`);
+    await registry.registerByKid(key.kid, Buffer.from(key.publicKey).toString("hex"), undefined, "2026-01-01T00:00:00.000Z");
+    expect(registry.historyByKid(key.kid)).toEqual(registry.getHistory(DID));
+  });
+});

--- a/trust-agent/src/key-registry.ts
+++ b/trust-agent/src/key-registry.ts
@@ -142,4 +142,25 @@ export class KeyRegistry {
   getHistory(did: string): readonly KeyEpoch[] {
     return this.epochsByDid.get(did) ?? [];
   }
+
+  // ─── kid-keyed convenience wrappers ────────────────────────────────────────
+  // A caller with an HTTP request usually only has a kid, not its DID — these
+  // derive it via didFromKid so every call site doesn't have to.
+
+  registerByKid(
+    kid: string,
+    publicKeyHex: string,
+    endorsement?: SignatureBlock,
+    now: string = new Date().toISOString()
+  ): Promise<void> {
+    return this.register(didFromKid(kid), kid, publicKeyHex, now, endorsement);
+  }
+
+  revokeByKid(kid: string, endorsement: SignatureBlock, now: string = new Date().toISOString()): Promise<void> {
+    return this.revoke(didFromKid(kid), now, endorsement);
+  }
+
+  historyByKid(kid: string): readonly KeyEpoch[] {
+    return this.getHistory(didFromKid(kid));
+  }
 }

--- a/trust-agent/src/ledger.test.ts
+++ b/trust-agent/src/ledger.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeMerkleRoot,
+  getMerkleProof,
+  verifyMerkleProof,
+  DAGLedger,
+  type ArtifactEnvelope,
+} from "./ledger.js";
+
+function artifact(traceId: string, timestamp = new Date().toISOString()): ArtifactEnvelope {
+  return {
+    envelope_type: "IntentEnvelope",
+    spec_version: "0.5",
+    trace_id: traceId,
+    timestamp,
+    expires_at: new Date(Date.now() + 30_000).toISOString(),
+    initiator: { did: "did:workload:agent#key-1", vc_ref: "urn:vc:1" },
+    target: {
+      did: "did:workload:bank-b#key-1",
+      mcp_deployment_id: "deploy-1",
+      tool_name: "transfer",
+      tool_schema_hash: "hash",
+      mcp_session_id: "session-1",
+    },
+    payload: { args_hash: "hash", nonce: "nonce" },
+    signatures: [],
+  } as ArtifactEnvelope;
+}
+
+describe("computeMerkleRoot", () => {
+  it("throws on an empty leaf set", () => {
+    expect(() => computeMerkleRoot([])).toThrow(/empty set/);
+  });
+
+  it("returns the single leaf as the root when there is only one leaf", () => {
+    expect(computeMerkleRoot(["a"])).toBe("a");
+  });
+
+  it("is deterministic for the same leaves", () => {
+    expect(computeMerkleRoot(["a", "b", "c"])).toBe(computeMerkleRoot(["a", "b", "c"]));
+  });
+
+  it("duplicates the last leaf when the leaf count is odd", () => {
+    const odd = computeMerkleRoot(["a", "b", "c"]);
+    const evenWithDup = computeMerkleRoot(["a", "b", "c", "c"]);
+    expect(odd).toBe(evenWithDup);
+  });
+
+  it("changes when any leaf changes", () => {
+    expect(computeMerkleRoot(["a", "b"])).not.toBe(computeMerkleRoot(["a", "x"]));
+  });
+});
+
+describe("getMerkleProof / verifyMerkleProof", () => {
+  it("produces a proof that verifies against the root for every leaf (even count)", () => {
+    const leaves = ["a", "b", "c", "d"];
+    const root = computeMerkleRoot(leaves);
+    leaves.forEach((leaf, i) => {
+      const proof = getMerkleProof(leaves, i);
+      expect(verifyMerkleProof(leaf, proof, root)).toBe(true);
+    });
+  });
+
+  it("produces a proof that verifies against the root for every leaf (odd count)", () => {
+    const leaves = ["a", "b", "c"];
+    const root = computeMerkleRoot(leaves);
+    leaves.forEach((leaf, i) => {
+      const proof = getMerkleProof(leaves, i);
+      expect(verifyMerkleProof(leaf, proof, root)).toBe(true);
+    });
+  });
+
+  it("fails verification for a tampered leaf", () => {
+    const leaves = ["a", "b", "c", "d"];
+    const root = computeMerkleRoot(leaves);
+    const proof = getMerkleProof(leaves, 1);
+    expect(verifyMerkleProof("tampered", proof, root)).toBe(false);
+  });
+});
+
+describe("DAGLedger.append", () => {
+  it("assigns sequential entry_id and stores the artifact", () => {
+    const ledger = new DAGLedger();
+    const e1 = ledger.append("INTENT_RECORD", artifact("trace-1"));
+    const e2 = ledger.append("INTENT_RECORD", artifact("trace-2"));
+    expect(e1.entry_id).toBe(1);
+    expect(e2.entry_id).toBe(2);
+    expect(e1.entry_hash).not.toBe(e2.entry_hash);
+  });
+
+  it("registers the entry in the timestamp registry by trace_id", () => {
+    const ledger = new DAGLedger();
+    ledger.append("INTENT_RECORD", artifact("trace-1"));
+    const history = ledger.getHistory("trace-1");
+    expect(history).toHaveLength(1);
+    expect(history[0].event_type).toBe("INTENT_RECORD");
+  });
+
+  it("auto-commits a batch once batchSize entries have been appended", () => {
+    const ledger = new DAGLedger(2);
+    ledger.append("INTENT_RECORD", artifact("trace-1"));
+    expect(ledger.getBatches()).toHaveLength(0);
+    ledger.append("INTENT_RECORD", artifact("trace-2"));
+    expect(ledger.getBatches()).toHaveLength(1);
+    expect(ledger.getBatches()[0].entry_hashes).toHaveLength(2);
+  });
+
+  it("back-fills batch_id on entries and their timestamp records once batched", () => {
+    const ledger = new DAGLedger(1);
+    ledger.append("INTENT_RECORD", artifact("trace-1"));
+    const [entry] = ledger.getAllEntries();
+    expect(entry.batch_id).toBe(1);
+    expect(ledger.getHistory("trace-1")[0].batch_id).toBe(1);
+  });
+});
+
+describe("DAGLedger.flush", () => {
+  it("returns null when there are no pending entries", () => {
+    const ledger = new DAGLedger();
+    expect(ledger.flush()).toBeNull();
+  });
+
+  it("commits a partial batch on manual flush", () => {
+    const ledger = new DAGLedger(8);
+    ledger.append("INTENT_RECORD", artifact("trace-1"));
+    const batch = ledger.flush();
+    expect(batch).not.toBeNull();
+    expect(batch!.entry_hashes).toHaveLength(1);
+    expect(ledger.getBatches()).toHaveLength(1);
+  });
+});
+
+describe("DAGLedger.anchorBatch", () => {
+  it("sets anchored_at on the matching batch", () => {
+    const ledger = new DAGLedger(1);
+    ledger.append("INTENT_RECORD", artifact("trace-1"));
+    ledger.anchorBatch(1, "0xdeadbeef");
+    expect(ledger.getBatches()[0].anchored_at).toBe("0xdeadbeef");
+  });
+
+  it("throws when the batch does not exist", () => {
+    const ledger = new DAGLedger();
+    expect(() => ledger.anchorBatch(999, "0xdeadbeef")).toThrow(/not found/);
+  });
+});
+
+describe("DAGLedger.getDisputePack", () => {
+  it("returns records, entries, and inclusion proofs for a batched trace", () => {
+    const ledger = new DAGLedger(1);
+    ledger.append("INTENT_RECORD", artifact("trace-1"));
+    const pack = ledger.getDisputePack("trace-1");
+
+    expect(pack.records).toHaveLength(1);
+    expect(pack.entries).toHaveLength(1);
+    expect(pack.inclusionProofs).toHaveLength(1);
+
+    const { entry_hash, proof, batch } = pack.inclusionProofs[0];
+    expect(verifyMerkleProof(entry_hash, proof, batch.merkle_root)).toBe(true);
+  });
+
+  it("omits inclusion proofs for entries not yet batched", () => {
+    const ledger = new DAGLedger(8); // batch size 8, only 1 entry appended below
+    ledger.append("INTENT_RECORD", artifact("trace-1"));
+    const pack = ledger.getDisputePack("trace-1");
+    expect(pack.entries).toHaveLength(1);
+    expect(pack.inclusionProofs).toHaveLength(0);
+  });
+
+  it("returns empty results for an unknown trace_id", () => {
+    const ledger = new DAGLedger();
+    const pack = ledger.getDisputePack("unknown-trace");
+    expect(pack.records).toEqual([]);
+    expect(pack.entries).toEqual([]);
+    expect(pack.inclusionProofs).toEqual([]);
+  });
+});
+
+describe("DAGLedger.getAllEntries / getBatches", () => {
+  it("return defensive copies, not the internal arrays", () => {
+    const ledger = new DAGLedger();
+    ledger.append("INTENT_RECORD", artifact("trace-1"));
+    const entries = ledger.getAllEntries();
+    entries.push({} as any);
+    expect(ledger.getAllEntries()).toHaveLength(1);
+  });
+});

--- a/trust-agent/src/nonce-registry.test.ts
+++ b/trust-agent/src/nonce-registry.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { NonceRegistry } from "./nonce-registry.js";
+
+const DID = "did:workload:agent#key-1";
+
+describe("NonceRegistry.consume", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns true for a fresh nonce (first use)", () => {
+    const registry = new NonceRegistry();
+    const expiresAt = new Date(Date.now() + 30_000).toISOString();
+    expect(registry.consume(DID, "nonce-1", expiresAt)).toBe(true);
+  });
+
+  it("returns false when the same (did, nonce) is replayed", () => {
+    const registry = new NonceRegistry();
+    const expiresAt = new Date(Date.now() + 30_000).toISOString();
+    registry.consume(DID, "nonce-1", expiresAt);
+    expect(registry.consume(DID, "nonce-1", expiresAt)).toBe(false);
+  });
+
+  it("treats the same nonce as fresh for a different initiator", () => {
+    const registry = new NonceRegistry();
+    const expiresAt = new Date(Date.now() + 30_000).toISOString();
+    registry.consume(DID, "nonce-1", expiresAt);
+    expect(registry.consume("did:workload:other#key-1", "nonce-1", expiresAt)).toBe(true);
+  });
+
+  it("purges expired entries so a new nonce can reuse the slot after expiry", () => {
+    vi.useFakeTimers();
+    const registry = new NonceRegistry();
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const expiresAt = new Date(now + 1_000).toISOString(); // +1s, skew tolerance is 5s
+
+    registry.consume(DID, "nonce-1", expiresAt);
+    expect(registry.size()).toBe(1);
+
+    // Advance past expires_at + skew tolerance (5s)
+    vi.setSystemTime(now + 1_000 + 5_000 + 1);
+    // Consuming a different nonce triggers the lazy purge
+    registry.consume(DID, "nonce-2", new Date(now + 1_000 + 5_000 + 30_000).toISOString());
+    expect(registry.size()).toBe(1); // nonce-1 purged, nonce-2 present
+  });
+});
+
+describe("NonceRegistry.checkExpiry", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns true when now is before expires_at", () => {
+    const registry = new NonceRegistry();
+    const expiresAt = new Date(Date.now() + 30_000).toISOString();
+    expect(registry.checkExpiry(expiresAt)).toBe(true);
+  });
+
+  it("returns true when now is within the skew tolerance window past expires_at", () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const registry = new NonceRegistry();
+    const expiresAt = new Date(now - 1_000).toISOString(); // already expired by 1s
+    expect(registry.checkExpiry(expiresAt)).toBe(true); // within 5s skew tolerance
+  });
+
+  it("returns false once past expires_at + skew tolerance", () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const registry = new NonceRegistry();
+    const expiresAt = new Date(now - 5_001).toISOString(); // past 5s skew tolerance
+    expect(registry.checkExpiry(expiresAt)).toBe(false);
+  });
+});
+
+describe("NonceRegistry.size", () => {
+  it("reflects the number of tracked (did, nonce) entries", () => {
+    const registry = new NonceRegistry();
+    const expiresAt = new Date(Date.now() + 30_000).toISOString();
+    expect(registry.size()).toBe(0);
+    registry.consume(DID, "nonce-1", expiresAt);
+    registry.consume(DID, "nonce-2", expiresAt);
+    expect(registry.size()).toBe(2);
+  });
+});

--- a/trust-agent/src/risk-budget.test.ts
+++ b/trust-agent/src/risk-budget.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { RiskBudgetEngine, type AgentPolicy } from "./risk-budget.js";
+
+const DID = "did:workload:agent#key-1";
+
+function policy(overrides: Partial<AgentPolicy> = {}): AgentPolicy {
+  return {
+    did: DID,
+    maxSingleActionUsd: 100,
+    dailyBudgetUsd: 500,
+    allowedTools: ["*"],
+    ...overrides,
+  };
+}
+
+describe("RiskBudgetEngine.check", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("denies when no policy is registered for the initiator", () => {
+    const engine = new RiskBudgetEngine();
+    const result = engine.check(DID, "transfer", 10);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/No policy registered/);
+  });
+
+  it("allows a call within the tool whitelist, single-action cap, and daily budget", () => {
+    const engine = new RiskBudgetEngine();
+    engine.registerPolicy(policy());
+    const result = engine.check(DID, "transfer", 10);
+    expect(result.allowed).toBe(true);
+    expect(result.remainingDailyUsd).toBe(490);
+  });
+
+  it("denies a tool not in the explicit allowedTools whitelist", () => {
+    const engine = new RiskBudgetEngine();
+    engine.registerPolicy(policy({ allowedTools: ["read"] }));
+    const result = engine.check(DID, "transfer", 10);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/not in allowedTools/);
+  });
+
+  it("allows any tool when allowedTools contains the wildcard", () => {
+    const engine = new RiskBudgetEngine();
+    engine.registerPolicy(policy({ allowedTools: ["*"] }));
+    expect(engine.check(DID, "anything", 10).allowed).toBe(true);
+  });
+
+  it("denies when the single-action cap is exceeded", () => {
+    const engine = new RiskBudgetEngine();
+    engine.registerPolicy(policy({ maxSingleActionUsd: 50 }));
+    const result = engine.check(DID, "transfer", 51);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/exceeds single-action cap/);
+  });
+
+  it("denies when the rolling daily budget is exhausted", () => {
+    const engine = new RiskBudgetEngine();
+    engine.registerPolicy(policy({ dailyBudgetUsd: 100, maxSingleActionUsd: 1000 }));
+    engine.recordSpend(DID, 95);
+    const result = engine.check(DID, "transfer", 10);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/Insufficient daily budget/);
+    expect(result.remainingDailyUsd).toBe(5);
+  });
+
+  it("excludes spend older than 24h from the rolling budget window", () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    const engine = new RiskBudgetEngine();
+    engine.registerPolicy(policy({ dailyBudgetUsd: 100, maxSingleActionUsd: 1000 }));
+    engine.recordSpend(DID, 95);
+
+    // Advance 24h + 1ms — the old spend record should age out
+    vi.setSystemTime(now + 24 * 60 * 60 * 1000 + 1);
+    const result = engine.check(DID, "transfer", 50);
+    expect(result.allowed).toBe(true);
+    expect(result.remainingDailyUsd).toBe(50);
+  });
+});
+
+describe("RiskBudgetEngine.recordSpend", () => {
+  it("accumulates spend across multiple calls for the same agent", () => {
+    const engine = new RiskBudgetEngine();
+    engine.registerPolicy(policy({ dailyBudgetUsd: 100, maxSingleActionUsd: 1000 }));
+    engine.recordSpend(DID, 30);
+    engine.recordSpend(DID, 30);
+    const result = engine.check(DID, "transfer", 30);
+    expect(result.allowed).toBe(true);
+    expect(result.remainingDailyUsd).toBe(10);
+  });
+
+  it("tracks spend independently per agent", () => {
+    const engine = new RiskBudgetEngine();
+    const otherDid = "did:workload:other#key-1";
+    engine.registerPolicy(policy({ dailyBudgetUsd: 100, maxSingleActionUsd: 1000 }));
+    engine.registerPolicy(policy({ did: otherDid, dailyBudgetUsd: 100, maxSingleActionUsd: 1000 }));
+    engine.recordSpend(DID, 90);
+    expect(engine.check(otherDid, "transfer", 90).allowed).toBe(true);
+  });
+});

--- a/trust-agent/src/trust-proxy.test.ts
+++ b/trust-agent/src/trust-proxy.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { generateKeyPair } from "./crypto.js";
 import type { KeyPair } from "./crypto.js";
-import { buildAcceptanceReceipt } from "./envelopes.js";
+import { buildAcceptanceReceipt, buildIntentEnvelope, buildExecutionEnvelope } from "./envelopes.js";
 import type { IntentEnvelope } from "./envelopes.js";
-import { ProxyAGateway } from "./trust-proxy.js";
-import type { McpToolCall } from "./trust-proxy.js";
+import { ProxyAGateway, ProxyBGateway } from "./trust-proxy.js";
+import type { McpToolCall, PublicKeySource } from "./trust-proxy.js";
 import { DegradedModeGate } from "./degraded-mode.js";
+import { NonceRegistry } from "./nonce-registry.js";
+import { RiskBudgetEngine, type AgentPolicy } from "./risk-budget.js";
+import { DAGLedger } from "./ledger.js";
 
 const WITNESS_URL = "http://witness.test";
 const PROXY_B_URL = "http://proxy-b.test";
@@ -219,5 +222,316 @@ describe("ProxyAGateway degraded-mode fallback (Delta #7)", () => {
 
     expect(result.error).toBeDefined();
     expect(executeTool).not.toHaveBeenCalled();
+  });
+});
+
+describe("ProxyAGateway — Proxy B accept phase", () => {
+  it("returns an mcpError and does not execute when Proxy B rejects the intent", async () => {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (String(url).endsWith("/accept")) {
+          return { ok: false, status: 400, json: async () => ({ error: "Insufficient daily budget" }) } as unknown as Response;
+        }
+        throw new Error(`unexpected fetch to ${url}`);
+      })
+    );
+
+    const gateway = new ProxyAGateway({ proxyKey: proxyAKey, proxyBEndpoint: PROXY_B_URL });
+    const executeTool = vi.fn(async () => ({ ok: true }));
+    const result = await gateway.forwardToolCall(makeCall(), executeTool);
+
+    expect(result.error?.message).toBe("Insufficient daily budget");
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it("returns an mcpError when Proxy B is unreachable", async () => {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("ECONNREFUSED");
+      })
+    );
+
+    const gateway = new ProxyAGateway({ proxyKey: proxyAKey, proxyBEndpoint: PROXY_B_URL });
+    const executeTool = vi.fn(async () => ({ ok: true }));
+    const result = await gateway.forwardToolCall(makeCall(), executeTool);
+
+    expect(result.error?.message).toMatch(/Proxy B unreachable/);
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+});
+
+describe("ProxyAGateway — tool execution and Proxy B execution relay", () => {
+  it("returns an mcpError when the tool itself throws", async () => {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+    installFetch(proxyBKey, async () => jsonResponse({}));
+
+    const gateway = new ProxyAGateway({ proxyKey: proxyAKey, proxyBEndpoint: PROXY_B_URL });
+    const executeTool = vi.fn(async () => {
+      throw new Error("tool blew up");
+    });
+    const result = await gateway.forwardToolCall(makeCall(), executeTool);
+
+    expect(result.result).toBeUndefined();
+    expect(result.error?.message).toBe("Tool execution failed");
+  });
+
+  it("adopts Proxy B's dual-signed execution envelope from /executed when provided", async () => {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+    const dualSignedStub = { fake: "dual-signed-execution-envelope" };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, opts?: { body?: string }) => {
+        const u = String(url);
+        if (u.endsWith("/accept")) {
+          const body = JSON.parse(opts!.body!) as { intent: IntentEnvelope };
+          const acceptance = await buildAcceptanceReceipt({
+            intentEnvelope: body.intent,
+            policyEvalInput: { decision: "ACCEPTED" },
+            proxyKey: proxyBKey,
+          });
+          return jsonResponse({ acceptance });
+        }
+        if (u.endsWith("/executed")) return jsonResponse({ execution: dualSignedStub });
+        throw new Error(`unexpected fetch to ${u}`);
+      })
+    );
+
+    const gateway = new ProxyAGateway({ proxyKey: proxyAKey, proxyBEndpoint: PROXY_B_URL });
+    const executeTool = vi.fn(async () => ({ ok: true }));
+    const result = await gateway.forwardToolCall(makeCall(), executeTool);
+
+    expect(result.result?._a2a?.execution_envelope).toEqual(dualSignedStub);
+  });
+});
+
+describe("ProxyBGateway.handleIntent", () => {
+  const DID = "did:workload:bank-a-agent";
+  const TOOL = "execute_wire_transfer";
+
+  async function makeIntent(proxyAKey: KeyPair, overrides: Partial<Parameters<typeof buildIntentEnvelope>[0]> = {}) {
+    return buildIntentEnvelope({
+      initiatorDid: DID,
+      vcRef: "vc:test",
+      targetDid: "did:workload:bank-b-proxy",
+      mcpDeploymentId: "did:workload:bank-b-proxy",
+      toolName: TOOL,
+      toolSchemaHash: "deadbeef",
+      mcpSessionId: "sess-1",
+      args: { amount: 100 },
+      proxyKey: proxyAKey,
+      ...overrides,
+    });
+  }
+
+  function makeGateway(proxyBKey: KeyPair, proxyAPublicKeys: PublicKeySource, opts: { policy?: AgentPolicy } = {}) {
+    const budgetEngine = new RiskBudgetEngine();
+    if (opts.policy) budgetEngine.registerPolicy(opts.policy);
+    const gateway = new ProxyBGateway({
+      proxyKey: proxyBKey,
+      proxyAPublicKeys,
+      nonceRegistry: new NonceRegistry(),
+      budgetEngine,
+      ledger: new DAGLedger(),
+    });
+    return { gateway, budgetEngine };
+  }
+
+  function keyMap(proxyAKey: KeyPair): PublicKeySource {
+    return new Map([[proxyAKey.kid, proxyAKey.publicKey]]);
+  }
+
+  it("accepts a valid intent within budget and records it in the ledger", async () => {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+    const { envelope: intent } = await makeIntent(proxyAKey);
+    const { gateway } = makeGateway(proxyBKey, keyMap(proxyAKey), {
+      policy: { did: DID, maxSingleActionUsd: 1000, dailyBudgetUsd: 1000, allowedTools: ["*"] },
+    });
+
+    const result = await gateway.handleIntent(intent, 50);
+
+    expect(result.error).toBeUndefined();
+    expect(result.acceptance?.decision).toBe("ACCEPTED");
+  });
+
+  it("denies via manualRejection without running any other checks", async () => {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+    const { envelope: intent } = await makeIntent(proxyAKey);
+    const { gateway } = makeGateway(proxyBKey, keyMap(proxyAKey));
+
+    const result = await gateway.handleIntent(intent, 50, { reason: "policy hold", errorCode: -32099 });
+
+    expect(result.error).toBe("policy hold");
+    expect(result.errorCode).toBe(-32099);
+    expect(result.denial?.decision).toBe("REJECTED");
+  });
+
+  it("denies an expired intent", async () => {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+    const { envelope: intent } = await makeIntent(proxyAKey, { ttlSeconds: -60 });
+    const { gateway } = makeGateway(proxyBKey, keyMap(proxyAKey), {
+      policy: { did: DID, maxSingleActionUsd: 1000, dailyBudgetUsd: 1000, allowedTools: ["*"] },
+    });
+
+    const result = await gateway.handleIntent(intent, 50);
+
+    expect(result.error).toMatch(/expired/);
+  });
+
+  it("denies a replayed intent (same initiator + nonce twice)", async () => {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+    const { envelope: intent } = await makeIntent(proxyAKey);
+    const { gateway } = makeGateway(proxyBKey, keyMap(proxyAKey), {
+      policy: { did: DID, maxSingleActionUsd: 1000, dailyBudgetUsd: 1000, allowedTools: ["*"] },
+    });
+
+    await gateway.handleIntent(intent, 50);
+    const result = await gateway.handleIntent(intent, 50);
+
+    expect(result.error).toMatch(/Replay detected/);
+  });
+
+  it("denies an intent missing a proxy signature", async () => {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+    const { envelope: baseIntent } = await makeIntent(proxyAKey);
+    const intent = { ...baseIntent, signatures: [] };
+    const { gateway } = makeGateway(proxyBKey, keyMap(proxyAKey), {
+      policy: { did: DID, maxSingleActionUsd: 1000, dailyBudgetUsd: 1000, allowedTools: ["*"] },
+    });
+
+    const result = await gateway.handleIntent(intent, 50);
+
+    expect(result.error).toMatch(/Missing proxy signature/);
+  });
+
+  it("denies an intent signed by an unregistered key id", async () => {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+    const { envelope: intent } = await makeIntent(proxyAKey);
+    const { gateway } = makeGateway(proxyBKey, new Map(), {
+      policy: { did: DID, maxSingleActionUsd: 1000, dailyBudgetUsd: 1000, allowedTools: ["*"] },
+    });
+
+    const result = await gateway.handleIntent(intent, 50);
+
+    expect(result.error).toMatch(/Unknown key id/);
+  });
+
+  it("denies a tampered intent (signature no longer verifies)", async () => {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+    const { envelope: baseIntent } = await makeIntent(proxyAKey);
+    const intent = { ...baseIntent, payload: { ...baseIntent.payload, args_hash: "tampered" } };
+    const { gateway } = makeGateway(proxyBKey, keyMap(proxyAKey), {
+      policy: { did: DID, maxSingleActionUsd: 1000, dailyBudgetUsd: 1000, allowedTools: ["*"] },
+    });
+
+    const result = await gateway.handleIntent(intent, 50);
+
+    expect(result.error).toMatch(/Signature verification failed/);
+  });
+
+  it("denies when the risk budget engine rejects the call", async () => {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+    const { envelope: intent } = await makeIntent(proxyAKey);
+    const { gateway } = makeGateway(proxyBKey, keyMap(proxyAKey), {
+      policy: { did: DID, maxSingleActionUsd: 10, dailyBudgetUsd: 1000, allowedTools: ["*"] },
+    });
+
+    const result = await gateway.handleIntent(intent, 500);
+
+    expect(result.errorCode).toBe(-32002);
+    expect(result.error).toMatch(/exceeds single-action cap/);
+  });
+});
+
+describe("ProxyBGateway.handleExecution", () => {
+  const DID = "did:workload:bank-a-agent";
+
+  async function acceptedFlow() {
+    const proxyAKey = await generateKeyPair("did:workload:bank-a-proxy#key-1");
+    const proxyBKey = await generateKeyPair("did:workload:bank-b-proxy#key-1");
+    const budgetEngine = new RiskBudgetEngine();
+    budgetEngine.registerPolicy({ did: DID, maxSingleActionUsd: 1000, dailyBudgetUsd: 1000, allowedTools: ["*"] });
+    const ledger = new DAGLedger();
+    const gateway = new ProxyBGateway({
+      proxyKey: proxyBKey,
+      proxyAPublicKeys: new Map([[proxyAKey.kid, proxyAKey.publicKey]]),
+      nonceRegistry: new NonceRegistry(),
+      budgetEngine,
+      ledger,
+    });
+
+    const { envelope: intent } = await buildIntentEnvelope({
+      initiatorDid: DID,
+      vcRef: "vc:test",
+      targetDid: "did:workload:bank-b-proxy",
+      mcpDeploymentId: "did:workload:bank-b-proxy",
+      toolName: "execute_wire_transfer",
+      toolSchemaHash: "deadbeef",
+      mcpSessionId: "sess-1",
+      args: { amount: 100 },
+      proxyKey: proxyAKey,
+    });
+    const acceptResult = await gateway.handleIntent(intent, 50);
+    const execution = await buildExecutionEnvelope({
+      intentEnvelope: intent,
+      acceptanceReceipt: acceptResult.acceptance!,
+      status: "COMPLETED",
+      outputData: { ok: true },
+      proxyKey: proxyAKey,
+    });
+    return { gateway, budgetEngine, ledger, execution };
+  }
+
+  it("counter-signs the execution envelope (dual-sign, D1)", async () => {
+    const { gateway, execution } = await acceptedFlow();
+    const dualSigned = await gateway.handleExecution(execution);
+    expect(dualSigned.signatures).toHaveLength(2);
+    expect(dualSigned.signatures[1].role).toBe("proxy");
+  });
+
+  it("records spend and persists an EXECUTION_RECORD when status is COMPLETED", async () => {
+    const { gateway, budgetEngine, ledger, execution } = await acceptedFlow();
+    const spy = vi.spyOn(budgetEngine, "recordSpend");
+
+    const dualSigned = await gateway.handleExecution(execution);
+
+    expect(spy).toHaveBeenCalledWith(DID, 50);
+    const history = ledger.getHistory(execution.trace_id);
+    expect(history.some((r) => r.event_type === "EXECUTION_RECORD")).toBe(true);
+    expect(dualSigned.trace_id).toBe(execution.trace_id);
+  });
+
+  it("does not record spend when status is FAILED", async () => {
+    const { gateway, budgetEngine, execution } = await acceptedFlow();
+    const spy = vi.spyOn(budgetEngine, "recordSpend");
+    const failed = { ...execution, status: "FAILED" as const };
+
+    await gateway.handleExecution(failed);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("cleans up per-transaction metadata so a second call for the same trace does not re-record spend", async () => {
+    const { gateway, budgetEngine, execution } = await acceptedFlow();
+    const spy = vi.spyOn(budgetEngine, "recordSpend");
+
+    await gateway.handleExecution(execution);
+    await gateway.handleExecution(execution); // trace_id metadata already cleaned up
+
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/trust-agent/vitest.config.ts
+++ b/trust-agent/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],
-      include: ["src/crypto.ts", "src/hash-chain.ts", "src/co-sign.ts", "src/worm.ts", "src/worm-store.ts", "src/key-registry.ts", "src/degraded-mode.ts"],
+      include: ["src/crypto.ts", "src/hash-chain.ts", "src/co-sign.ts", "src/worm.ts", "src/worm-store.ts", "src/key-registry.ts", "src/degraded-mode.ts", "src/blob-store-sql.ts"],
       thresholds: {
         lines: 80,
         functions: 80,


### PR DESCRIPTION
## Summary

Investigated the repo for DRY/KISS opportunities (per request) and refactored the three concrete, safe wins found:

1. **WORM blob-store SQL** — `trust-agent-cloud/src/blob-db.ts` and `Bank-A/proxy/src/worm-db.ts` were ~95% byte-identical (same write-once CRUD, same schema, different table/function names). Extracted into `trust-agent/src/blob-store-sql.ts` (`initBlobTable`/`createBlobStore`), taking a minimal structural `SqlDatabase` interface rather than importing `better-sqlite3` itself — keeps `@trustagentai/a2a-core` storage-agnostic (that package's runtime `dependencies` are untouched; `better-sqlite3` is a **devDependency only**, for this module's own tests). Both call sites shrank to thin ~30-line bindings; no other file needed to change (same exported function names).
2. **Key-registry kid→DID plumbing** — `didFromKid(kid)` + `register`/`revoke`/`getHistory` was duplicated in the witness's `CoSignService` and Bank-B's `server.ts`. Added `registerByKid`/`revokeByKid`/`historyByKid` to `KeyRegistry` itself; `CoSignService`'s existing public methods now delegate to them (unchanged API, tests untouched); Bank-B calls them directly.
3. **`key-exchange.ts`** — `registerWithProxyB`/`registerWithWitness` were identical except the target path and log label; consolidated into one `registerWithPeer` helper.

## What I deliberately did NOT change (and why)

- **HTTP route validation glue** (`if (!kid || !publicKeyHex) {...}` + try/catch in the register/revoke endpoints) is still duplicated across the witness and Bank-B. After (2) above, what's left per handler is ~10 lines of Express-specific boilerplate. Sharing it would require either adding `express` as a dependency of core (breaks the framework-agnostic boundary the codebase has consistently held since Delta #1) or standing up a new shared internal package just for this — more infrastructure than the duplication it removes. Flagging as a known, low-value-to-fix item rather than silently leaving it unexamined.
- **`Bank-A/proxy/src/server.ts` (479 lines) and `Bank-B/proxy/src/server.ts` (464 lines)** exceed this repo's own ≤400-lines/file guideline. Splitting route handlers into separate files is a real KISS win but touches the main entrypoint of each service extensively — out of scope for this pass; noted for a future, dedicated cleanup.

## Tests

- `trust-agent`: 80/80 passing (6 new for `blob-store-sql.ts`, 3 new for `KeyRegistry.*ByKid`). `blob-store-sql.ts` 95%/87%/100%/95% (stmt/branch/func/line).
- `trust-agent-cloud`: 14/14 passing, unchanged (proves `CoSignService`'s public API and `blob-db.ts`'s exports are unaffected).
- `trust-agent`, `trust-agent-cloud`, `Bank-A/proxy`, `Bank-B/proxy` all build clean (`tsc`).
- No behavior change anywhere — every existing test passed without modification except the `KeyRegistry` test file, which only gained new tests.

## Test plan

- [x] `cd trust-agent && npm run build && npm run test:coverage`
- [x] `cd trust-agent-cloud && npm install && npm run build && npm test`
- [x] `cd Bank-A/proxy && npm install && npm run build`
- [x] `cd Bank-B/proxy && npm run build`